### PR TITLE
Update sed command for compatibility with MacOS

### DIFF
--- a/scripts/prepare-dotenv.sh
+++ b/scripts/prepare-dotenv.sh
@@ -13,10 +13,19 @@ else
 
   for environment in $environments
   do
-      # Create a copy of .env.sample for each environment
-      cp .env.sample .env.$environment
+    # Create a copy of .env.sample for each environment
+    cp .env.sample .env.$environment
 
-      # Replace ENV= with ENV=<environment> in each file
-      sed -i "s/^ENV=.*$/ENV=$environment/g" .env.$environment
+    # Replace ENV= with ENV=<environment> in each file
+    # The command differs depending on the Unix-based system (Linux/BSD) or Mac, due to differences in the sed command
+    # - On GNU sed (default on Linux), no space is used between -i and '' (or ""): sed -i'' 's/foo/bar/g'.
+    # - On BSD sed (default on MacOS), a space is required between -i and '' (or ""): sed -i '' 's/foo/bar/g'.
+    if [ "$(uname)" = "Darwin" ]; then
+      # Mac OS X
+      sed -i '' -e "s/^ENV=.*$/ENV=$environment/g" .env.$environment
+    else
+      # Linux and others
+      sed -i'' -e "s/^ENV=.*$/ENV=$environment/g" .env.$environment
+    fi
   done
 fi


### PR DESCRIPTION
## Summary

It adapted the sed command in the `prepare-dotenv.sh` script to ensure compatibility with MacOS and Linux. Previously, the script only worked on Linux systems, but now it accounts for differences in the sed command on Unix-based systems.

<!-- README: DELETE THIS COMMENT BLOCK after
      - Providing a quick summary of the changes yourself
-->

## Issue

The `prepare-dotenv.sh` shell script was using `sed` with the format just for Linux so anyone using OSx will get a silence error during `yarn install`

## Type of change

Select one or more:

- [ ] New feature, functionality or library
- [x] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## Testing

**Documentation changes** (only if making doc changes)
- [ ] `make docusaurus_start`; only needed if you make doc changes

**Local Testing** (only if making code changes)
- [ ] **Unit Tests**: `make go_develop_and_test`
- [ ] **LocalNet E2E Tests**: `make test_e2e`
- See [quickstart guide](https://dev.poktroll.com/developer_guide/quickstart) for instructions

**PR Testing** (only if making code changes)
- [ ] **DevNet E2E Tests**: Add the `devnet-test-e2e` label to the PR.
    - **THIS IS VERY EXPENSIVE**, so only do it after all the reviews are complete.
    - Optionally run `make trigger_ci` if you want to re-trigger tests without any code changes
    - If tests fail, try re-running failed tests only using the GitHub UI as shown [here](https://github.com/pokt-network/poktroll/assets/1892194/607984e9-0615-4569-9452-4c730190c1d2)


## Sanity Checklist

- [x] I have tested my changes using the available tooling
- [x] I have commented my code
- [x] I have performed a self-review of my own code; both comments & source code
- [ ] I create and reference any new tickets, if applicable
- [ ] I have left TODOs throughout the codebase, if applicable
