### PR TITLE
Add public key utilities and refactor address handling

### DIFF
--- a/src/mappings/utils/handlers.ts
+++ b/src/mappings/utils/handlers.ts
@@ -35,8 +35,8 @@ export async function unprocessedMsgHandler(err: Error, msg: CosmosMessage): Pro
 }
 
 export async function trackUnprocessed(error: Error, primitives: Primitives): Promise<void> {
-  logger.warn(`[trackUnprocessable] (error.message): ${error.message}`);
-  logger.warn(`[trackUnprocessable] (error.stack): ${error.stack}`);
+  logger.error(`[trackUnprocessable] (error.message): ${error.message}`);
+  logger.trace(`[trackUnprocessable] (error.stack): ${error.stack}`);
   // NB: failsafe try/catch
   try {
     const { block, event, msg, tx } = primitives;
@@ -70,6 +70,6 @@ export async function trackUnprocessed(error: Error, primitives: Primitives): Pr
     return await unprocessedEntity.save();
   } catch {
     logger.error("[trackUnprocessable] (ERROR): unable to persist unprocessable entity");
-    logger.error(`[trackUnprocessable] (ERROR | stack): ${error.stack}`);
+    logger.trace(`[trackUnprocessable] (ERROR | stack): ${error.stack}`);
   }
 }

--- a/src/mappings/utils/pub_key.ts
+++ b/src/mappings/utils/pub_key.ts
@@ -40,7 +40,7 @@ function rawSecp256k1PubKeyToRawAddress(pubKey: Uint8Array): Uint8Array {
   return ripemd160(sha256(pk));
 }
 
-function pubKeyToRawAddress(type: string, pubKey: Uint8Array, prefix?: string) {
+function pubKeyToRawAddress(type: string, pubKey: Uint8Array, prefix?: string): string {
   switch (type) {
     case Ed25519:
       return toHex(rawEd25519PubKeyToRawAddress(pubKey)).toUpperCase();

--- a/src/mappings/utils/pub_key.ts
+++ b/src/mappings/utils/pub_key.ts
@@ -1,0 +1,64 @@
+import {
+  ripemd160,
+  sha256,
+} from "@cosmjs/crypto";
+import {
+  fromBase64,
+  toBech32,
+  toHex,
+} from "@cosmjs/encoding";
+import {
+  isEmpty,
+  isNil,
+} from "lodash";
+
+export const Secp256k1 = "/cosmos.crypto.secp256k1.PubKey";
+export const Ed25519 = "/cosmos.crypto.ed25519.PubKey";
+
+function rawEd25519PubKeyToRawAddress(pubKey: Uint8Array): Uint8Array {
+  if (pubKey.length !== 32) {
+    throw new Error(`Invalid Ed25519 pub key length: ${pubKey.length}`);
+  }
+  return sha256(pubKey).slice(0, 20);
+}
+
+function rawSecp256k1PubKeyToRawAddress(pubKey: Uint8Array): Uint8Array {
+  let pk = pubKey;
+
+  if (pubKey.length === 35) {
+    // NB: pubKey has 2 "extra" bytes at the beginning as compared to the
+    // base64-decoded representation/ of the same key when imported to
+    // fetchd (`fetchd keys add --recover`) and shown (`fetchd keys show`).
+    // Inspired from https://github.com/bryanchriswhite/fetchai-ledger-subquery/blob/main/src/mappings/primitives.ts#L71
+    pk = pubKey.slice(2);
+  }
+
+  if (pk.length !== 33) {
+    throw new Error(`Invalid Secp256k1 pub key length: ${pk.length}`);
+  }
+
+  return ripemd160(sha256(pk));
+}
+
+function pubKeyToRawAddress(type: string, pubKey: Uint8Array, prefix?: string) {
+  switch (type) {
+    case Ed25519:
+      return toHex(rawEd25519PubKeyToRawAddress(pubKey)).toUpperCase();
+    case Secp256k1:
+      if (isEmpty(prefix) || isNil(prefix)) {
+        throw new Error("Bench32 Prefix should not be empty");
+      }
+      return toBech32(prefix, rawSecp256k1PubKeyToRawAddress(pubKey));
+    default:
+      // Keep this case here to guard against new types being added but not handled
+      throw new Error(`pubKey type ${type} not supported`);
+  }
+}
+
+export function base64PubKeyToAddress(type: string, base64PubKey: string, prefix?: string): string {
+  return pubKeyToRawAddress(type, fromBase64(base64PubKey), prefix);
+}
+
+export function pubKeyToAddress(type: string, pubKey: Uint8Array, prefix?: string): string {
+  return pubKeyToRawAddress(type, pubKey, prefix);
+}


### PR DESCRIPTION
## Summary

- Introduced utility functions in `pub_key.ts` to handle public key conversions and address encoding.
- Refactored `primitives.ts` to use new utility methods for translating public keys to addresses.
- Adjusted logging levels in `handlers.ts` for better error tracking and debugging: changed warning to error for message logging and error to trace for stack logging.

## Issue

The signer of the transactions was not properly handled and due that they txs looks like was signed for a different address than which was the right one.

## Type of change

Select one or more:

- [ ] New feature, functionality or library
- [x] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## Sanity Checklist

- [x] I have tested my changes using the available tooling
- [x] I have commented my code
- [x] I have performed a self-review of my own code; both comments & source code
- [ ] I create and reference any new tickets, if applicable
- [x] I have left TODOs throughout the codebase, if applicable
