### PR TITLE
fixed getEventId and added genesis messages

### DIFF
--- a/src/mappings/utils/ids.ts
+++ b/src/mappings/utils/ids.ts
@@ -12,7 +12,7 @@ export function messageId(msg: CosmosMessage | CosmosEvent): string {
 // getEventId returns the id of the event passed.
 // Use this to get the id of the events across the indexing process.
 export function getEventId(event: CosmosEvent): string {
-  return `${event.tx?.hash || event.block.blockId}-${event.idx}`;
+  return `${event.tx?.hash || event.block.block.id}-${event.idx}`;
 }
 
 // getBalanceId returns the id of the Balance entity using the address and denom passed.


### PR DESCRIPTION
## Summary

- Added genesis messages
- Fixed getEventId

## Issue

- getEventId was returning `[object Object]-83` when a transaction hash was not defined. The part `[object Object]` of the id should've been the id of the block.
- The messages for the Stake transactions weren't being created.

## Type of change

Select one or more:

- [x] New feature, functionality or library
- [x] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## Sanity Checklist

- [x] I have tested my changes using the available tooling
- [x] I have commented my code
- [x] I have performed a self-review of my own code; both comments & source code
- [ ] I create and reference any new tickets, if applicable
- [ ] I have left TODOs throughout the codebase, if applicable
