### PR TITLE
Added handler of EventRelayMiningDifficultyUpdated and bug fixes

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -758,14 +758,6 @@ type EventRelayMiningDifficultyUpdated @entity {
   event: Event!
 }
 
-#message EventRelayMiningDifficultyUpdated {
-#    string service_id = 1;
-#    string prev_target_hash_hex_encoded = 2;
-#    string new_target_hash_hex_encoded = 3;
-#    uint64 prev_num_relays_ema = 4;
-#    uint64 new_num_relays_ema = 5;
-#}
-
 type Gateway @entity {
   # id is the address of the gateway
   id: ID!

--- a/schema.graphql
+++ b/schema.graphql
@@ -292,6 +292,7 @@ type Transaction @entity {
   status: TxStatus! @index
   log: String
   code: Int!
+  idx: Int!
   codespace: String
   timeoutHeight: BigInt @index
   # NB: only the first signer!
@@ -302,6 +303,7 @@ type Transaction @entity {
 
 type Message @entity {
   id: ID!
+  idx: Int!
   typeUrl: String! @index
   json: String
   transaction: Transaction!
@@ -311,6 +313,7 @@ type Message @entity {
 
 type Event @entity {
   id: ID!
+  idx: Int!
   type: String! @index
   kind: EventKind!
   attributes: [EventAttribute]!
@@ -444,6 +447,12 @@ type Service @entity {
   computeUnitsPerRelay: BigInt!
   owner: Account!
   addServiceMsgs: [MsgAddService] @derivedFrom(field: "service")
+  relayMiningDifficultyUpdatedEvents: [EventRelayMiningDifficultyUpdated] @derivedFrom(field: "service")
+  # data from the last EventRelayMiningDifficultyUpdated event
+  prevTargetHashHexEncoded: String
+  newTargetHashHexEncoded: String
+  prevNumRelaysEma: BigInt
+  newNumRelaysEma: BigInt
 }
 
 type MsgStakeApplication @entity {
@@ -737,6 +746,25 @@ type MsgAddService @entity {
   transaction: Transaction!
   message: Message!
 }
+
+type EventRelayMiningDifficultyUpdated @entity {
+  id: ID!
+  service: Service!
+  prevTargetHashHexEncoded: String!
+  newTargetHashHexEncoded: String!
+  prevNumRelaysEma: BigInt!
+  newNumRelaysEma: BigInt!
+  block: Block!
+  event: Event!
+}
+
+#message EventRelayMiningDifficultyUpdated {
+#    string service_id = 1;
+#    string prev_target_hash_hex_encoded = 2;
+#    string new_target_hash_hex_encoded = 3;
+#    uint64 prev_num_relays_ema = 4;
+#    uint64 new_num_relays_ema = 5;
+#}
 
 type Gateway @entity {
   # id is the address of the gateway

--- a/src/mappings/authz/exec.ts
+++ b/src/mappings/authz/exec.ts
@@ -42,6 +42,7 @@ function _handleAuthzExec(msg: CosmosMessage<AuthzExecMsg>): HandleAuthzExecResu
 
   result.messages.push({
     id: authzExecId,
+    idx: msg.idx,
     typeUrl,
     json: stringify(msg.msg.decodedMsg),
     transactionId: msg.tx.hash,
@@ -85,6 +86,7 @@ function _handleAuthzExec(msg: CosmosMessage<AuthzExecMsg>): HandleAuthzExecResu
       // Create a primitive message entity for a sub-message
       result.messages.push({
         id: subMsgId,
+        idx: msg.idx,
         typeUrl,
         json: stringify(decodedMsg),
         transactionId: msg.tx.hash,

--- a/src/mappings/handlers.ts
+++ b/src/mappings/handlers.ts
@@ -32,7 +32,7 @@ import {
   handleMsgCreateClaim,
   handleMsgSubmitProof,
 } from "./poktroll/relays";
-import { handleMsgAddService } from "./poktroll/services";
+import { handleEventRelayMiningDifficultyUpdated, handleMsgAddService } from "./poktroll/services";
 import {
   handleSupplierStakeMsg,
   handleSupplierUnbondingBeginEvent,
@@ -126,6 +126,8 @@ export const EventHandlers: Record<string, (events: Array<CosmosEvent>) => Promi
   // supplier
   "poktroll.supplier.EventSupplierUnbondingBegin": handleSupplierUnbondingBeginEvent,
   "poktroll.supplier.EventSupplierUnbondingEnd": handleSupplierUnbondingEndEvent,
+  // service
+  "poktroll.service.EventRelayMiningDifficultyUpdated": handleEventRelayMiningDifficultyUpdated,
   // gateway
   "poktroll.gateway.EventGatewayUnstaked": handleGatewayUnstakeEvent,
   "poktroll.gateway.EventGatewayUnbondingBegin": handleEventGatewayUnbondingBegin,
@@ -144,5 +146,4 @@ export const EventHandlers: Record<string, (events: Array<CosmosEvent>) => Promi
   "coinbase": noOp,
   "transfer": noOp,
   "burn": noOp,
-  "poktroll.service.EventRelayMiningDifficultyUpdated": noOp,
 };

--- a/src/mappings/indexer.manager.ts
+++ b/src/mappings/indexer.manager.ts
@@ -43,6 +43,7 @@ import {
   filterEventsByTxStatus,
   filterMsgByTxStatus,
   hasValidAmountAttribute,
+  isEventOfFinalizedBlockKind,
 } from "./utils/primitives";
 
 function handleByType(typeUrl: string | Array<string>, byTypeMap: MessageByType | EventByType, byTypeHandlers: typeof MsgHandlers | typeof EventHandlers, byTxStatus: ByTxStatus): Array<Promise<void>> {
@@ -78,57 +79,6 @@ function handleByType(typeUrl: string | Array<string>, byTypeMap: MessageByType 
   }
 
   return promises;
-}
-
-async function handleStakeMsgs(typeUrl: string, identityProperty: string, msgByType: MessageByType) {
-  const { success: msgs } = filterMsgByTxStatus(msgByType[typeUrl]);
-  const addressMsgMap: Record<string, Array<CosmosMessage>> = {};
-
-  if (msgs.length === 0) {
-    return;
-  }
-
-  msgs.forEach((msg) => {
-    const identity = get(msg.msg.decodedMsg, identityProperty) as string;
-    if (!addressMsgMap[identity]) addressMsgMap[identity] = [];
-    addressMsgMap[identity].push(msg);
-  });
-
-  const nonRepeatedStake = [];
-  const repeatedStakeAddresses = new Set<string>();
-  for (const [identity, msgs] of Object.entries(addressMsgMap)) {
-    if (msgs.length === 1) {
-      nonRepeatedStake.push(...msgs);
-    } else {
-      repeatedStakeAddresses.add(identity);
-    }
-  }
-
-  const promises: Array<Promise<void>> = [
-    // call in parallel application stake handler for all non-repeated stake messages
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
-    MsgHandlers[typeUrl](nonRepeatedStake),
-  ];
-
-  for (const identity of repeatedStakeAddresses.values()) {
-    const msgs = addressMsgMap[identity];
-    msgs[0].tx.idx;
-    msgs[0].idx;
-    const sortedMsg = orderBy(msgs, ["tx.idx", "idx"], ["asc", "asc"]);
-    promises.push(async function(msgs) {
-      for (const msg of msgs) {
-        // force pass one by one because they are at the same block and the same address,
-        // so we need to enforce tx.idx + tx.msg.idx
-        // otherwise the resultant state of Application entity could not reflect the right state on the network.
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-ignore
-        await MsgHandlers[typeUrl]([msg]);
-      }
-    }(sortedMsg));
-  }
-
-  await Promise.all(promises);
 }
 
 // anything primitive types
@@ -230,8 +180,9 @@ async function indexRelays(msgByType: MessageByType, eventByType: EventByType): 
     "poktroll.tokenomics.EventClaimExpired",
     "poktroll.proof.EventClaimUpdated",
     "poktroll.proof.EventProofUpdated",
-    // todo: handle this events
-    //  poktroll.tokenomics.EventApplicationReimbursementRequest
+    "poktroll.proof.EventProofValidityChecked",
+    "poktroll.tokenomics.EventApplicationOverserviced",
+    "poktroll.tokenomics.EventApplicationReimbursementRequest"
   ];
 
   await Promise.all([
@@ -248,10 +199,29 @@ async function indexParams(msgByType: MessageByType): Promise<void> {
 }
 
 // any service msg or event
-async function indexService(msgByType: MessageByType): Promise<void> {
-  await Promise.all(
-    handleByType("/poktroll.service.MsgAddService", msgByType, MsgHandlers, ByTxStatus.Success),
-  );
+async function indexService(msgByType: MessageByType, eventByType: EventByType): Promise<void> {
+  const eventTypes = [
+    "poktroll.service.EventRelayMiningDifficultyUpdated",
+  ];
+  const msgTypes = [
+    "/poktroll.service.MsgAddService",
+  ];
+
+  await indexStakeEntity([
+    ...msgTypes.map(type => msgByType[type]).flat(),
+    ...eventTypes.map(type => eventByType[type]).flat()
+  ], {
+    "/poktroll.service.MsgAddService": "service.id",
+    "poktroll.service.EventRelayMiningDifficultyUpdated": (attributes) => {
+      for (const attribute of attributes) {
+        if (attribute.key === "service_id") {
+          return JSON.parse(attribute.value as string).service_id
+        }
+      }
+
+      return null
+    }
+  })
 }
 
 // any application msg or event
@@ -260,6 +230,7 @@ async function indexApplications(msgByType: MessageByType, eventByType: EventByT
     "/poktroll.application.MsgDelegateToGateway",
     "/poktroll.application.MsgUndelegateFromGateway",
     "/poktroll.application.MsgUnstakeApplication",
+    "/poktroll.application.MsgStakeApplication",
     "/poktroll.application.MsgTransferApplication",
   ];
   const eventTypes = [
@@ -270,23 +241,58 @@ async function indexApplications(msgByType: MessageByType, eventByType: EventByT
     "poktroll.application.EventApplicationUnbondingEnd",
   ];
 
-  await Promise.all([
-    handleStakeMsgs(
-      "/poktroll.application.MsgStakeApplication",
-      "address",
-      msgByType,
-    ),
-    // handle possible edge case where same entity receive on same block multiple stake msgs
-    ...handleByType(msgTypes, msgByType, MsgHandlers, ByTxStatus.Success),
-    // any other non-stake msgs/events
-    ...handleByType(eventTypes, eventByType, EventHandlers, ByTxStatus.Success),
-  ]);
+  const getIdOfTransferEvents = (attributes: CosmosEvent['event']["attributes"]) => {
+    return attributes.find(({key}) => key === "source_address")?.value as string
+  }
+
+  const getIdOfBondingEvents = (attributes: CosmosEvent['event']["attributes"]) => {
+    for (const {key, value} of attributes) {
+      if (key !== "application") continue
+
+      return JSON.parse(value as string).address
+    }
+
+    return null
+  }
+
+  await indexStakeEntity([
+    ...msgTypes.map(type => msgByType[type]).flat(),
+    ...eventTypes.map(type => eventByType[type]).flat()
+  ],
+  {
+    "/poktroll.application.MsgDelegateToGateway": "appAddress",
+    "/poktroll.application.MsgUndelegateFromGateway": "appAddress",
+    "/poktroll.application.MsgUnstakeApplication": "address",
+    "/poktroll.application.MsgStakeApplication": "address",
+    "/poktroll.application.MsgTransferApplication": "sourceAddress",
+    "poktroll.application.EventTransferBegin": getIdOfTransferEvents,
+    "poktroll.application.EventTransferEnd": (attributes) => {
+      // here we need to return two ids (id of the source and id of the destination app)
+      // to group the data of those two apps
+      const ids: Array<string> = []
+
+      for (const {key, value} of attributes) {
+        if (key === 'source_address' || key === 'destination_address') {
+          // the source address is surrounded by quotes
+          ids.push((value as string).replaceAll("\"", ""))
+        }
+
+        if (ids.length === 2) break
+      }
+
+      return ids
+    },
+    "poktroll.application.EventTransferError": getIdOfTransferEvents,
+    "poktroll.application.EventApplicationUnbondingBegin": getIdOfBondingEvents,
+    "poktroll.application.EventApplicationUnbondingEnd": getIdOfBondingEvents,
+  })
 }
 
 // any gateway msg or event
 async function indexGateway(msgByType: MessageByType, eventByType: EventByType): Promise<void> {
   const msgTypes = [
     "/poktroll.gateway.MsgUnstakeGateway",
+    "/poktroll.gateway.MsgStakeGateway",
   ];
   const eventTypes = [
     "poktroll.gateway.EventGatewayUnstaked",
@@ -294,41 +300,230 @@ async function indexGateway(msgByType: MessageByType, eventByType: EventByType):
     "poktroll.gateway.EventGatewayUnbondingEnd",
   ];
 
-  await handleStakeMsgs(
-    "/poktroll.gateway.MsgStakeGateway",
-    "address",
-    msgByType,
-  );
+  const getIdOfUnbondingEvents = (attributes: CosmosEvent["event"]["attributes"]) => {
+    for (const {key, value} of attributes) {
+      if (key !== "gateway") continue
+      return JSON.parse(value as string).address
+    }
+    return null
+  }
 
-  await Promise.all([
-    // handle possible edge case where same entity receive on same block multiple stake msgs
-    ...handleByType(msgTypes, msgByType, MsgHandlers, ByTxStatus.Success),
-    // any other non-stake msgs/events
-    ...handleByType(eventTypes, eventByType, EventHandlers, ByTxStatus.Success),
-  ]);
+  await indexStakeEntity([
+    ...msgTypes.map(type => msgByType[type]).flat(),
+    ...eventTypes.map(type => eventByType[type]).flat()
+  ],
+  {
+    "/poktroll.gateway.MsgStakeGateway": "address",
+    "/poktroll.gateway.MsgUnstakeGateway": "address",
+    "poktroll.gateway.EventGatewayUnstaked": getIdOfUnbondingEvents,
+    "poktroll.gateway.EventGatewayUnbondingBegin": getIdOfUnbondingEvents,
+    "poktroll.gateway.EventGatewayUnbondingEnd": getIdOfUnbondingEvents,
+
+  })
+}
+
+// this is used to group more than one entity that are updated in the same handler
+// for example, when a EventTransferEnd is emitted, two appliations are updated
+function groupConnectedComponents(arrays: string[][]): string[][] {
+  const adjacencyList = new Map<string, Set<string>>();
+
+  // Build adjacency list
+  for (const group of arrays) {
+    for (const item of group) {
+      if (!adjacencyList.has(item)) {
+        adjacencyList.set(item, new Set());
+      }
+      for (const other of group) {
+        if (item !== other) {
+          adjacencyList.get(item)!.add(other);
+        }
+      }
+    }
+  }
+
+  const visited = new Set<string>();
+  const result: string[][] = [];
+
+  // DFS function to traverse components
+  function dfs(node: string, component: string[]) {
+    if (visited.has(node)) return;
+    visited.add(node);
+    component.push(node);
+    for (const neighbor of adjacencyList.get(node) || []) {
+      dfs(neighbor, component);
+    }
+  }
+
+  // Find all connected components
+  for (const node of adjacencyList.keys()) {
+    if (!visited.has(node)) {
+      const component: string[] = [];
+      dfs(node, component);
+      result.push(component.sort()); // Sort for consistency
+    }
+  }
+
+  return result;
+}
+
+type GetIdFromEventAttribute = (attributes: CosmosEvent["event"]["attributes"]) => string | Array<string>;
+
+/*
+This function is used to call handlers in order to avoid updating the same entity twice or more at the same time
+  data is an array of cosmos events or messages
+  getEntityIdArg is a record of string or function that returns a string,
+    for messages it is the path of the decodedMsg to get the entity id
+    for events it is a function that receives the attributes and returns the entity id
+*/
+async function indexStakeEntity(data: Array<CosmosEvent | CosmosMessage>, getEntityIdArg: Record<string, string | GetIdFromEventAttribute>) {
+  // this is to handle events where more than one stake entity is updated
+  // like in _handleTransferApplicationEndEvent handler
+  const entitiesUpdatedAtSameDatum: Array<Array<string>> = [];
+  const dataByEntityId: Record<string, {
+    finalizedEvents: Array<CosmosEvent>,
+    // rank here is used to mark messages as 0 and events as 1 to sort ascending
+    // prioritizing messages over events (that are not finalized events)
+    nonFinalizedData: Array<(CosmosEvent | CosmosMessage) & {rank: 1 | 0}>
+  }> = {}
+
+
+  for (const datum of data) {
+    // if event in datum them is a cosmos event
+    if ('event' in datum) {
+      const getEntityId = getEntityIdArg[datum.event.type] as GetIdFromEventAttribute
+
+      if (!getEntityId) throw new Error(`getIdFromEventAttribute not found for event type ${datum.event.type}`)
+      let entityId = getEntityId(datum.event.attributes)
+
+      if (Array.isArray(entityId)) {
+        entitiesUpdatedAtSameDatum.push(entityId)
+        // we are only taking the first one because later we will get the data for every entity in this group
+        // it is redundant to save the data for every entity in this group
+        entityId = entityId.at(0)!
+      }
+
+      // some events have their attributes values in double quotes
+      // so we need to remove them, it is better to remove them here instead of in the handler
+      entityId = entityId.replaceAll('"', '')
+
+      if (!dataByEntityId[entityId]) {
+        dataByEntityId[entityId] = {
+          finalizedEvents: [],
+          nonFinalizedData: [],
+        }
+      }
+
+      const isFinalizedBlockEvent = isEventOfFinalizedBlockKind(datum)
+
+      dataByEntityId[entityId][isFinalizedBlockEvent ? 'finalizedEvents' : 'nonFinalizedData'].push({
+        ...datum,
+          rank: 1,
+      })
+    } else {
+      const entityIdPath = getEntityIdArg[datum.msg.typeUrl] as string
+      if (!entityIdPath) throw new Error(`getIdFromEventAttribute not found for msg type ${datum.msg.typeUrl}`)
+
+      const entityId = get(datum.msg.decodedMsg, entityIdPath)
+
+      if (!dataByEntityId[entityId]) {
+        dataByEntityId[entityId] = {
+          finalizedEvents: [],
+          nonFinalizedData: [],
+        }
+      }
+
+      dataByEntityId[entityId].nonFinalizedData.push({
+        ...datum,
+        rank: 0
+      })
+    }
+  }
+
+  // this is to group entities that were updated in the same event/msg
+  for (const groupedConnectedEntities of groupConnectedComponents(entitiesUpdatedAtSameDatum)) {
+    const id = groupedConnectedEntities.join('-')
+
+    const finalizedEvents: Array<CosmosEvent> = []
+    const nonFinalizedData: Array<(CosmosEvent | CosmosMessage) & {rank: 1|0}> = []
+
+    for (const entity of groupedConnectedEntities) {
+      const data = dataByEntityId[entity]
+      if (!data) continue
+
+      finalizedEvents.push(...data.finalizedEvents)
+      nonFinalizedData.push(...data.nonFinalizedData)
+      delete dataByEntityId[entity]
+    }
+
+    dataByEntityId[id] = {
+      finalizedEvents,
+      nonFinalizedData
+    }
+  }
+
+  await Promise.all(
+    Object.entries(dataByEntityId).map(async ([id,data]) => {
+      const finalizedEvents = orderBy(data.finalizedEvents, ['idx'], ['asc'])
+      const nonFinalizedData = orderBy(data.nonFinalizedData, ['tx.idx', 'rank', 'idx'], ['asc', 'asc', 'asc'])
+
+      for (const nonFinalizedDatum of nonFinalizedData) {
+        if ('event' in nonFinalizedDatum) {
+          await EventHandlers[nonFinalizedDatum.event.type]([nonFinalizedDatum])
+        } else {
+          await MsgHandlers[nonFinalizedDatum.msg.typeUrl]([nonFinalizedDatum])
+        }
+      }
+
+      for (const finalizedEvent of finalizedEvents) {
+        await EventHandlers[finalizedEvent.event.type]([finalizedEvent])
+      }
+    })
+  )
 }
 
 // any supplier msg or event
 async function indexSupplier(msgByType: MessageByType, eventByType: EventByType): Promise<void> {
   const msgTypes = [
     "/poktroll.supplier.MsgUnstakeSupplier",
+    "/poktroll.supplier.MsgStakeSupplier",
   ];
   const eventTypes = [
     "poktroll.supplier.EventSupplierUnbondingBegin",
     "poktroll.supplier.EventSupplierUnbondingEnd",
+    // this is here because it modifies the staked tokens of the supplier
+    "poktroll.tokenomics.EventSupplierSlashed"
   ];
 
-  // handle possible edge case where same entity receive on same block multiple stake msgs
-  await handleStakeMsgs(
-    "/poktroll.supplier.MsgStakeSupplier",
-    "operatorAddress",
-    msgByType,
-  );
 
-  await Promise.all([
-    ...handleByType(msgTypes, msgByType, MsgHandlers, ByTxStatus.Success),
-    ...handleByType(eventTypes, eventByType, EventHandlers, ByTxStatus.Success),
-  ]);
+  const eventGetId = (attributes: CosmosEvent["event"]["attributes"]) => {
+    for (const attribute of attributes) {
+      if (attribute.key !== "supplier") continue
+      return JSON.parse(attribute.value as string).operator_address
+    }
+
+    return null
+  }
+
+  await indexStakeEntity(
+    [
+      ...msgTypes.map(type => msgByType[type]).flat(),
+      ...eventTypes.map(type => eventByType[type]).flat()
+    ],
+  {
+    "/poktroll.supplier.MsgUnstakeSupplier": "operatorAddress",
+    "/poktroll.supplier.MsgStakeSupplier": "operatorAddress",
+    "poktroll.supplier.EventSupplierUnbondingBegin": eventGetId,
+    "poktroll.supplier.EventSupplierUnbondingEnd": eventGetId,
+    "poktroll.tokenomics.EventSupplierSlashed": (attributes) => {
+      for (const attribute of attributes) {
+        if (attribute.key === "claim") {
+          return JSON.parse(attribute.value as string).supplier_operator_address
+        }
+      }
+
+      return null
+    }
+  })
 }
 
 // any message or event related to stake (supplier, gateway, application, service)
@@ -450,7 +645,7 @@ async function _indexingHandler(block: CosmosBlock): Promise<void> {
   await Promise.all([
     profilerWrap(indexBalances, "indexingHandler", "indexBalances")(block, msgsByType as MessageByType, eventsByType),
     profilerWrap(indexParams, "indexingHandler", "indexParams")(msgsByType as MessageByType),
-    profilerWrap(indexService, "indexingHandler", "indexService")(msgsByType as MessageByType),
+    profilerWrap(indexService, "indexingHandler", "indexService")(msgsByType as MessageByType, eventsByType),
     profilerWrap(indexValidators, "indexingHandler", "indexValidators")(msgsByType as MessageByType, eventsByType),
     profilerWrap(indexStake, "indexingHandler", "indexStake")(msgsByType as MessageByType, eventsByType),
     profilerWrap(indexRelays, "indexingHandler", "indexRelays")(msgsByType as MessageByType, eventsByType),

--- a/src/mappings/indexer.manager.ts
+++ b/src/mappings/indexer.manager.ts
@@ -35,6 +35,7 @@ import {
   EventByType,
   MessageByType,
 } from "./types/common";
+import { GetIdFromEventAttribute, RecordGetId } from "./types/stake";
 import { optimizedBulkCreate } from "./utils/db";
 import { getBlockId } from "./utils/ids";
 import { stringify } from "./utils/json";
@@ -366,7 +367,6 @@ function groupConnectedComponents(arrays: string[][]): string[][] {
   return result;
 }
 
-type GetIdFromEventAttribute = (attributes: CosmosEvent["event"]["attributes"]) => string | Array<string>;
 
 /*
 This function is used to call handlers in order to avoid updating the same entity twice or more at the same time
@@ -375,7 +375,7 @@ This function is used to call handlers in order to avoid updating the same entit
     for messages it is the path of the decodedMsg to get the entity id
     for events it is a function that receives the attributes and returns the entity id
 */
-async function indexStakeEntity(data: Array<CosmosEvent | CosmosMessage>, getEntityIdArg: Record<string, string | GetIdFromEventAttribute>) {
+async function indexStakeEntity(data: Array<CosmosEvent | CosmosMessage>, getEntityIdArg: RecordGetId) {
   // this is to handle events where more than one stake entity is updated
   // like in _handleTransferApplicationEndEvent handler
   const entitiesUpdatedAtSameDatum: Array<Array<string>> = [];

--- a/src/mappings/poktroll/pagination.ts
+++ b/src/mappings/poktroll/pagination.ts
@@ -129,6 +129,19 @@ export async function fetchAllGatewayByUnstakingEndBlockId(blockId: bigint): Pro
   });
 }
 
+
+export async function fetchAllApplicationGatewayByGatewayId(gatewayId: string): Promise<ApplicationGateway[]> {
+  return fetchPaginatedRecords({
+    fetchFn: (options) => ApplicationGateway.getByGatewayId(gatewayId, options),
+    initialOptions: {
+      // add order and direction to speedup if there is a way
+      // orderBy: 'id', // Order results by ID
+      // orderDirection: 'ASC', // Ascending order
+    },
+  });
+}
+
+
 // relays
 
 export async function fetchAllEventClaimSettled(blockId: bigint): Promise<EventClaimSettled[]> {

--- a/src/mappings/poktroll/relays.ts
+++ b/src/mappings/poktroll/relays.ts
@@ -168,15 +168,15 @@ function getAttributes(attributes: CosmosEvent["event"]["attributes"]) {
       numRelays = BigInt(parseAttribute(attribute.value));
     }
 
-    if (attribute.key === "num_claimed_computed_units") {
+    if (attribute.key === "num_claimed_compute_units") {
       numClaimedComputedUnits = BigInt(parseAttribute(attribute.value));
     }
 
-    if (attribute.key === "num_estimated_computed_units") {
+    if (attribute.key === "num_estimated_compute_units") {
       numEstimatedComputedUnits = BigInt(parseAttribute(attribute.value));
     }
 
-    if (attribute.key === "claimed") {
+    if (attribute.key === "claimed_upokt") {
       claimed = JSON.parse(attribute.value as string);
     }
 

--- a/src/mappings/poktroll/reports.ts
+++ b/src/mappings/poktroll/reports.ts
@@ -56,7 +56,7 @@ export async function handleAddBlockReports(block: CosmosBlock): Promise<void> {
     getUnstakedAppsData(blockHeight),
     getStakedGatewaysData(),
     getUnstakedGatewaysData(blockHeight),
-  ] as const);
+  ]);
 
   blockEntity.totalComputedUnits = computedUnits;
   blockEntity.totalRelays = relays;

--- a/src/mappings/poktroll/services.ts
+++ b/src/mappings/poktroll/services.ts
@@ -1,11 +1,14 @@
-import { CosmosMessage } from "@subql/types-cosmos";
+import { CosmosEvent, CosmosMessage } from "@subql/types-cosmos";
+import { omit, orderBy } from "lodash";
 import {
   MsgAddService as MsgAddServiceEntity,
   Service,
 } from "../../types";
+import { EventRelayMiningDifficultyUpdatedProps } from "../../types/models/EventRelayMiningDifficultyUpdated";
 import { MsgAddService } from "../../types/proto-interfaces/poktroll/service/tx";
 import {
   getBlockId,
+  getEventId,
   messageId,
 } from "../utils/ids";
 
@@ -37,6 +40,117 @@ async function _handleMsgAddService(
   ]);
 }
 
+// we are returning the idx because we need it to get the latest event per service
+// to update the relay mining difficulty of the service entity
+function _handleEventRelayMiningDifficultyUpdated(event: CosmosEvent): EventRelayMiningDifficultyUpdatedProps & {idx: number} {
+  let serviceId = '',
+    prevTargetHashHexEncoded = '',
+    newTargetHashHexEncoded = '',
+    prevNumRelaysEma: bigint | null = null,
+    newNumRelaysEma: bigint | null = null;
+
+  for (const attribute of event.event.attributes) {
+    const value = (attribute.value as string).replaceAll('"', '')
+
+    if (attribute.key === "service_id") {
+      serviceId = value
+    }
+
+    if (attribute.key === "prev_target_hash_hex_encoded") {
+      prevTargetHashHexEncoded = value
+    }
+
+    if (attribute.key === "new_target_hash_hex_encoded") {
+      newTargetHashHexEncoded = value
+    }
+
+    if (attribute.key === "prev_num_relays_ema") {
+      prevNumRelaysEma = BigInt(value)
+    }
+
+    if (attribute.key === "new_num_relays_ema") {
+      newNumRelaysEma = BigInt(value)
+    }
+  }
+
+  if (!serviceId) {
+    throw new Error(`[handleEventRelayMiningDifficultyUpdated] serviceId not found in event`);
+  }
+
+  if (!prevTargetHashHexEncoded) {
+    throw new Error(`[handleEventRelayMiningDifficultyUpdated] prevTargetHashHexEncoded not found in event`);
+  }
+
+  if (!newTargetHashHexEncoded) {
+    throw new Error(`[handleEventRelayMiningDifficultyUpdated] newTargetHashHexEncoded not found in event`);
+  }
+
+  if (!prevNumRelaysEma) {
+    throw new Error(`[handleEventRelayMiningDifficultyUpdated] prevNumRelaysEma not found in event`);
+  }
+
+  if (!newNumRelaysEma) {
+    throw new Error(`[handleEventRelayMiningDifficultyUpdated] newNumRelaysEma not found in event`);
+  }
+
+  const eventId = getEventId(event)
+
+  return {
+    id: eventId,
+    serviceId,
+    prevTargetHashHexEncoded,
+    newTargetHashHexEncoded,
+    prevNumRelaysEma,
+    newNumRelaysEma,
+    blockId: getBlockId(event.block),
+    eventId: eventId,
+    idx: event.idx
+  }
+}
+
+async function _updateRelayMiningDifficultyOfService(relayMiningDifficultyUpdatedProps: EventRelayMiningDifficultyUpdatedProps) {
+  const service = await Service.get(relayMiningDifficultyUpdatedProps.serviceId)
+
+  if (!service) {
+    throw new Error(`[handleEventRelayMiningDifficultyUpdated] service not found for id ${relayMiningDifficultyUpdatedProps.serviceId}`)
+  }
+
+  service.prevTargetHashHexEncoded = relayMiningDifficultyUpdatedProps.prevTargetHashHexEncoded
+  service.newTargetHashHexEncoded = relayMiningDifficultyUpdatedProps.newTargetHashHexEncoded
+  service.prevNumRelaysEma = relayMiningDifficultyUpdatedProps.prevNumRelaysEma
+  service.newNumRelaysEma = relayMiningDifficultyUpdatedProps.newNumRelaysEma
+
+  await service.save()
+}
+
 export async function handleMsgAddService(messages: Array<CosmosMessage<MsgAddService>>): Promise<void> {
   await Promise.all(messages.map(_handleMsgAddService));
+}
+
+export async function handleEventRelayMiningDifficultyUpdated(events: Array<CosmosEvent>): Promise<void> {
+  const relayMiningDifficultyUpdatedEvents = events.map(_handleEventRelayMiningDifficultyUpdated)
+  const eventsWithoutIdx: Array<EventRelayMiningDifficultyUpdatedProps> = []
+
+  const eventsGroupedByServiceId = relayMiningDifficultyUpdatedEvents.reduce((acc, event) => {
+    const serviceId = event.serviceId
+
+    if (!acc[serviceId]) {
+      acc[serviceId] = []
+    }
+
+    acc[serviceId].push(event)
+    eventsWithoutIdx.push(omit(event, 'idx'))
+
+    return acc
+  }, {} as Record<string, Array<EventRelayMiningDifficultyUpdatedProps>>)
+
+
+  await Promise.all([
+    store.bulkCreate("EventRelayMiningDifficultyUpdated", eventsWithoutIdx),
+    Object.values(eventsGroupedByServiceId).map(async (eventsOfService) => {
+      const sortedEvents = orderBy(eventsOfService, ['idx'], ['asc'])
+
+      await _updateRelayMiningDifficultyOfService(sortedEvents.at(-1)!)
+    })
+  ])
 }

--- a/src/mappings/primitives/events.ts
+++ b/src/mappings/primitives/events.ts
@@ -28,6 +28,7 @@ function _handleEvent(event: CosmosEvent): EventProps {
   const blockId = getBlockId(event.block);
   return {
     id,
+    idx: event.idx,
     type: event.event.type,
     kind: kind,
     attributes: attributes,

--- a/src/mappings/primitives/genesis.ts
+++ b/src/mappings/primitives/genesis.ts
@@ -281,6 +281,7 @@ async function _handleAuthz(genesis: Genesis, block: CosmosBlock): Promise<void>
 async function _handleGenesisEvent(block: CosmosBlock): Promise<void> {
   await Event.create({
     id: "genesis",
+    idx: 0,
     type: "genesis",
     attributes: [],
     blockId: getBlockId(block),
@@ -374,6 +375,7 @@ async function _handleGenesisServices(genesis: Genesis, block: CosmosBlock): Pro
 
     transactions.push({
       id: transactionHash,
+      idx: 0,
       blockId: getBlockId(block),
       gasUsed: BigInt(0),
       gasWanted: BigInt(0),
@@ -398,6 +400,7 @@ async function _handleGenesisServices(genesis: Genesis, block: CosmosBlock): Pro
 
     msgs.push({
       id: msgId,
+      idx: 0,
       typeUrl: "/poktroll.service.MsgAddService",
       json: stringify(msgAddService),
       blockId: getBlockId(block),
@@ -428,6 +431,7 @@ async function _handleGenesisSuppliers(genesis: Genesis, block: CosmosBlock): Pr
 
     transactions.push({
       id: transactionHash,
+      idx: 0,
       blockId: getBlockId(block),
       gasUsed: BigInt(0),
       gasWanted: BigInt(0),
@@ -489,6 +493,7 @@ async function _handleGenesisSuppliers(genesis: Genesis, block: CosmosBlock): Pr
 
     msgs.push({
       id: msgId,
+      idx: 0,
       typeUrl: "/poktroll.supplier.MsgStakeSupplier",
       json: stringify(msgStakeSupplier),
       blockId: getBlockId(block),
@@ -555,6 +560,7 @@ async function _handleGenesisApplications(genesis: Genesis, block: CosmosBlock):
 
     transactions.push({
       id: transactionHash,
+      idx: 0,
       blockId: getBlockId(block),
       gasUsed: BigInt(0),
       gasWanted: BigInt(0),
@@ -618,6 +624,7 @@ async function _handleGenesisApplications(genesis: Genesis, block: CosmosBlock):
 
     msgs.push({
       id: msgId,
+      idx: 0,
       typeUrl: "/poktroll.application.MsgStakeApplication",
       json: stringify(msgStakeApplication),
       blockId: getBlockId(block),
@@ -666,6 +673,7 @@ async function _handleGenesisGateways(genesis: Genesis, block: CosmosBlock): Pro
 
     transactions.push({
       id: transactionHash,
+      idx: 0,
       blockId: getBlockId(block),
       gasUsed: BigInt(0),
       gasWanted: BigInt(0),
@@ -706,6 +714,7 @@ async function _handleGenesisGateways(genesis: Genesis, block: CosmosBlock): Pro
 
     msgs.push({
       id: msgId,
+      idx: 0,
       typeUrl: "/poktroll.gateway.MsgStakeGateway",
       json: stringify(msgStakeGateway),
       blockId: getBlockId(block),
@@ -831,6 +840,7 @@ async function _handleGenesisGenTxs(genesis: Genesis, block: CosmosBlock): Promi
 
         messages.push({
           id: validatorMsg.id,
+          idx: 0,
           typeUrl: type,
           json: stringify(genTx.body.messages[0]),
           blockId: getBlockId(block),
@@ -845,6 +855,7 @@ async function _handleGenesisGenTxs(genesis: Genesis, block: CosmosBlock): Promi
 
     transactions.push({
       id: txHash,
+      idx: 0,
       blockId: getBlockId(block),
       signerAddress,
       gasUsed: BigInt(0),

--- a/src/mappings/primitives/messages.ts
+++ b/src/mappings/primitives/messages.ts
@@ -11,6 +11,7 @@ function _handleMessage(msg: CosmosMessage): MessageProps {
   delete msg.msg?.decodedMsg?.wasmByteCode;
   return {
     id: messageId(msg),
+    idx: msg.idx,
     typeUrl: msg.msg.typeUrl,
     json: stringify(msg.msg.decodedMsg),
     transactionId: msg.tx.hash,

--- a/src/mappings/primitives/transactions.ts
+++ b/src/mappings/primitives/transactions.ts
@@ -35,6 +35,7 @@ function _handleTransaction(tx: CosmosTransaction): TransactionProps {
 
   return {
     id: tx.hash,
+    idx: tx.idx,
     blockId: getBlockId(tx.block),
     gasUsed: tx.tx.gasUsed,
     gasWanted: tx.tx.gasWanted,

--- a/src/mappings/types/stake.ts
+++ b/src/mappings/types/stake.ts
@@ -1,0 +1,5 @@
+import { CosmosEvent } from "@subql/types-cosmos";
+
+export type GetIdFromEventAttribute = (attributes: CosmosEvent["event"]["attributes"]) => string | Array<string>;
+
+export type RecordGetId = Record<string, string | GetIdFromEventAttribute>

--- a/src/mappings/utils/db.ts
+++ b/src/mappings/utils/db.ts
@@ -156,8 +156,9 @@ export async function optimizedBulkCreate(modelName: string, docs: Array<any>, t
       });
 
       await transaction.commit()
-    } catch {
+    } catch (e) {
       await transaction.rollback()
+      throw e
     }
 
     // Update and log progress after successful batch creation

--- a/src/mappings/utils/primitives.ts
+++ b/src/mappings/utils/primitives.ts
@@ -53,7 +53,11 @@ export function isEventOfMessageOrTransactionKind(event: CosmosEvent): boolean {
 }
 
 export function isEventOfBlockKind(event: CosmosEvent): boolean {
-  return event.kind === CosmosEventKind.BeginBlock || event.kind === CosmosEventKind.EndBlock || event.kind === CosmosEventKind.FinalizeBlock;
+  return event.kind === CosmosEventKind.BeginBlock || event.kind === CosmosEventKind.EndBlock || isEventOfFinalizedBlockKind(event);
+}
+
+export function isEventOfFinalizedBlockKind(event: CosmosEvent): boolean {
+  return event.kind === CosmosEventKind.FinalizeBlock;
 }
 
 // on block 1, all the events at finalizeBlock, for example,


### PR DESCRIPTION
## Summary

* Added handler of `EventRelayMiningDifficultyUpdated`
* Added `idx` field to Events, Messages and Transactions
* Fixed bug with applications when an application was being transferred, and it was re-staked then the transfer info was overwritten
* Added unhandled use case when an application was being delegated to a gateway and the gateway was unstaked, the delegate relation wasn't removed
* Fixed `numClaimedComputedUnits`, `numEstimatedComputedUnits` and `claimedAmount` of relays entities
* Updated `optimizedBulkCreate` util to create a transaction for every batch instead of reuse the transaction of subql to avoid errors when there are too many items to be saved (like in the block 72710)

## Issue

Missing event handler of `EventRelayMiningDifficultyUpdated` and some bugs that were explained in the summary

## Type of change

Select one or more:

- [x] New feature, functionality or library
- [x] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## Sanity Checklist

- [x] I have tested my changes using the available tooling
- [x] I have commented my code
- [x] I have performed a self-review of my own code; both comments & source code
- [ ] I create and reference any new tickets, if applicable
- [ ] I have left TODOs throughout the codebase, if applicable
