### PR TITLE
Fix handler of EventSupplierUnbondingEnd

### DIFF
--- a/src/mappings/poktroll/suppliers.ts
+++ b/src/mappings/poktroll/suppliers.ts
@@ -317,7 +317,7 @@ async function _handleSupplierUnbondingEndEvent(
     //  but alpha has still events without this
     logger.error(`[handleSupplierUnbondingEndEvent] unbonding_end_height not found`);
   } else {
-    supplier.unstakingEndBlockId = BigInt((unbondingHeight as unknown as string).replaceAll("\"", ""));
+    supplier.unstakingEndBlockId = unbondingHeight
   }
 
   if (!reason) {


### PR DESCRIPTION
## Summary

Fixed handler of `EventSupplierUnbondingEnd`

## Issue

We left a `replaceAll` call to a bigint const

## Type of change

Select one or more:

- [ ] New feature, functionality or library
- [x] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## Sanity Checklist

- [x] I have tested my changes using the available tooling
- [x] I have commented my code
- [x] I have performed a self-review of my own code; both comments & source code
- [ ] I create and reference any new tickets, if applicable
- [ ] I have left TODOs throughout the codebase, if applicable
