### PR TITLE
Fixed handling of reason on unbonding events

### DIFF
--- a/src/mappings/poktroll/applications.ts
+++ b/src/mappings/poktroll/applications.ts
@@ -405,7 +405,7 @@ async function _handleApplicationUnbondingBeginEvent(
 ) {
   const msg = event.msg as CosmosMessage<MsgUnstakeApplication>;
 
-  let unstakingEndHeight = BigInt(0), sessionEndHeight = BigInt(0), reason = 0;
+  let unstakingEndHeight = BigInt(0), sessionEndHeight = BigInt(0), reason: number | null = null;
 
   for (const attribute of event.event.attributes) {
     if (attribute.key === "unbonding_end_height") {
@@ -429,7 +429,7 @@ async function _handleApplicationUnbondingBeginEvent(
     throw new Error(`[handleApplicationUnbondingBeginEvent] sessionEndHeight not found in event`);
   }
 
-  if (!reason) {
+  if (reason === null) {
     throw new Error(`[handleApplicationUnbondingBeginEvent] reason not found in event`);
   }
 
@@ -462,7 +462,7 @@ async function _handleApplicationUnbondingBeginEvent(
 async function _handleApplicationUnbondingEndEvent(
   event: CosmosEvent,
 ) {
-  let unstakingEndHeight = BigInt(0), sessionEndHeight = BigInt(0), reason = 0,
+  let unstakingEndHeight = BigInt(0), sessionEndHeight = BigInt(0), reason: number | null = null,
     applicationSdk: ApplicationSDKType | undefined;
 
   for (const attribute of event.event.attributes) {
@@ -491,7 +491,7 @@ async function _handleApplicationUnbondingEndEvent(
     throw new Error(`[handleApplicationUnbondingEndEvent] sessionEndHeight not found in event`);
   }
 
-  if (!reason) {
+  if (reason === null) {
     throw new Error(`[handleApplicationUnbondingEndEvent] reason not found in event`);
   }
 

--- a/src/mappings/poktroll/suppliers.ts
+++ b/src/mappings/poktroll/suppliers.ts
@@ -209,7 +209,7 @@ async function _handleSupplierUnbondingBeginEvent(
   "value":"\"55070\"","index":true
   },{"key":"mode","value":"EndBlock","index":true}]}
    */
-  let unbondingHeight: bigint | null = null, sessionEndHeight: bigint | null = null, supplierSdk: SupplierSDKType | null = null, reason = 0;
+  let unbondingHeight: bigint | null = null, sessionEndHeight: bigint | null = null, supplierSdk: SupplierSDKType | null = null, reason: null | number = null;
 
   for (const attribute of event.event.attributes) {
     if (attribute.key === "supplier") {
@@ -252,7 +252,7 @@ async function _handleSupplierUnbondingBeginEvent(
     supplier.unstakingEndHeight = unbondingHeight
   }
 
-  if (!reason) {
+  if (reason === null) {
     // todo: we should do this -> throw new Error(`[handleSupplierUnbondingBeginEvent] reason not found in event`);
     //  but alpha has still events without this
     logger.error(`[handleSupplierUnbondingBeginEvent] reason not found in event`);
@@ -270,7 +270,7 @@ async function _handleSupplierUnbondingBeginEvent(
       sessionEndHeight: sessionEndHeight || BigInt(0),
       supplierId: operatorAddress,
       blockId: getBlockId(event.block),
-      reason: reason ? getSupplierUnbondingReasonFromSDK(reason) : SupplierUnbondingReason.UNSPECIFIED,
+      reason: reason !== null ? getSupplierUnbondingReasonFromSDK(reason) : SupplierUnbondingReason.UNSPECIFIED,
       eventId,
     }).save(),
   ]);
@@ -279,7 +279,7 @@ async function _handleSupplierUnbondingBeginEvent(
 async function _handleSupplierUnbondingEndEvent(
   event: CosmosEvent,
 ) {
-  let unbondingHeight: bigint | null = null, sessionEndHeight: bigint | null = null, supplierSdk: SupplierSDKType | null = null, reason = 0;
+  let unbondingHeight: bigint | null = null, sessionEndHeight: bigint | null = null, supplierSdk: SupplierSDKType | null = null, reason: null | number = null;
 
   for (const attribute of event.event.attributes) {
     if (attribute.key === "supplier") {
@@ -320,7 +320,7 @@ async function _handleSupplierUnbondingEndEvent(
     supplier.unstakingEndBlockId = unbondingHeight
   }
 
-  if (!reason) {
+  if (reason === null) {
     // todo: we should do this -> throw new Error(`[handleSupplierUnbondingBeginEvent] reason not found in event`);
     //  but alpha has still events without this
     logger.error(`[handleSupplierUnbondingEndEvent] reason not found in event`);
@@ -339,7 +339,7 @@ async function _handleSupplierUnbondingEndEvent(
       id: eventId,
       unbondingEndHeight: unbondingHeight || BigInt(0),
       sessionEndHeight: sessionEndHeight || BigInt(0),
-      reason: reason ? getSupplierUnbondingReasonFromSDK(reason) : SupplierUnbondingReason.UNSPECIFIED,
+      reason: reason !== null ? getSupplierUnbondingReasonFromSDK(reason) : SupplierUnbondingReason.UNSPECIFIED,
       blockId: getBlockId(event.block),
       supplierId: supplierSdk.operator_address,
       eventId,


### PR DESCRIPTION
## Summary

Fixed handling of reason on unbonding events for Applications and Suppliers

## Issue

The variable `reason` was of type `number`, receiving its value from an enum (i.e., by calling `applicationUnbondingReasonFromJSON`). We were incorrectly throwing an error when `reason` was **falsy** (`!reason`). This caused an issue when reason was the first item in the enum (with a value of `0`), as `0` is a valid value but was mistakenly treated as an error.

## Type of change

Select one or more:

- [ ] New feature, functionality or library
- [x] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## Sanity Checklist

- [x] I have tested my changes using the available tooling
- [x] I have commented my code
- [x] I have performed a self-review of my own code; both comments & source code
- [ ] I create and reference any new tickets, if applicable
- [ ] I have left TODOs throughout the codebase, if applicable
