### PR TITLE
Fix supplies

### DIFF
--- a/src/mappings/pocket/reports.ts
+++ b/src/mappings/pocket/reports.ts
@@ -209,10 +209,10 @@ async function getStakedSuppliersData() {
           tokens: BigInt(0),
           amount: 0,
         };
-      } else {
-        stakedSuppliersByServiceMap[serviceId].tokens += supplier.stakeAmount;
-        stakedSuppliersByServiceMap[serviceId].amount += 1;
       }
+
+      stakedSuppliersByServiceMap[serviceId].tokens += supplier.stakeAmount;
+      stakedSuppliersByServiceMap[serviceId].amount += 1;
     }
   }
 
@@ -307,10 +307,10 @@ async function getStakedAppsData() {
           tokens: BigInt(0),
           amount: 0,
         };
-      } else {
-        stakedAppsByServiceMap[serviceId].tokens += app.stakeAmount;
-        stakedAppsByServiceMap[serviceId].amount += 1;
       }
+
+      stakedAppsByServiceMap[serviceId].tokens += app.stakeAmount;
+      stakedAppsByServiceMap[serviceId].amount += 1;
     }
   }
 

--- a/src/mappings/primitives/genesis.ts
+++ b/src/mappings/primitives/genesis.ts
@@ -187,7 +187,7 @@ export async function handleGenesis(block: CosmosBlock): Promise<void> {
 }
 
 async function _handleModuleAccounts(block: CosmosBlock): Promise<void> {
-  const moduleAccounts = await queryModuleAccounts();
+  const moduleAccounts = await queryModuleAccounts(block);
 
   const accounts: Array<EnforceAccountExistenceParams> = [];
   // const mAccounts: Array<ModuleAccountProps> = [];

--- a/src/mappings/utils/query_client.ts
+++ b/src/mappings/utils/query_client.ts
@@ -1,0 +1,74 @@
+import { createPagination, ProtobufRpcClient, QueryClient } from "@cosmjs/stargate";
+import {QueryClientImpl as AuthQueryClientImpl} from 'cosmjs-types/cosmos/auth/v1beta1/query'
+import {
+  QueryAllBalancesRequest,
+  QueryClientImpl as BankQueryClientImpl,
+  QueryTotalSupplyResponse,
+} from "cosmjs-types/cosmos/bank/v1beta1/query";
+import { Coin } from "cosmjs-types/cosmos/base/v1beta1/coin";
+import { Any } from "cosmjs-types/google/protobuf/any";
+
+interface PocketdexExtension {
+  readonly bank: {
+    readonly totalSupply: (paginationKey?: Uint8Array) => Promise<QueryTotalSupplyResponse>;
+    readonly allBalances: (address: string) => Promise<Coin[]>;
+  }
+  readonly auth: {
+    readonly moduleAccounts: () => Promise<Any[]>;
+  }
+}
+
+export function createProtobufRpcClient(base: QueryClient, height?: number): ProtobufRpcClient {
+  return {
+    request: async (service: string, method: string, data: Uint8Array): Promise<Uint8Array> => {
+      const path = `/${service}/${method}`;
+      const response = await base.queryAbci(path, data, height);
+      return response.value;
+    },
+  };
+}
+
+const setupPocketdexExtension = (height?: number) => (base: QueryClient): PocketdexExtension => {
+  const rpc = createProtobufRpcClient(base, height);
+
+  // Use this service to get easy typed access to query methods
+  // This cannot be used for proof verification
+  const bankQueryService = new BankQueryClientImpl(rpc);
+  const authQueryService = new AuthQueryClientImpl(rpc);
+
+  return {
+    bank: {
+      totalSupply: async (paginationKey?: Uint8Array) => {
+        return bankQueryService.TotalSupply({
+          pagination: createPagination(paginationKey),
+        });
+      },
+      allBalances: async (address: string) => {
+        const { balances } = await bankQueryService.AllBalances(
+          QueryAllBalancesRequest.fromPartial({ address: address }),
+        );
+        return balances;
+      },
+    },
+    auth: {
+      moduleAccounts: async () => {
+        const { accounts } = await authQueryService.ModuleAccounts();
+        return accounts ?? [];
+      }
+    }
+  };
+}
+
+// The purpose of creating a new query client instead of using the one injected by subql
+// is because with the injected one, we cannot pass a custom height so it always queries the latest height.
+// With this new query client, we can pass a custom height, and it will query the data for the block that is being indexed.
+export default function getQueryClient(height: number): QueryClient & PocketdexExtension {
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
+  const cometClient = api.forceGetCometClient();
+
+  return QueryClient.withExtensions(
+    cometClient,
+    setupPocketdexExtension(height),
+  )
+}


### PR DESCRIPTION
## Summary

- Added getQueryClient to enable querying data from the block currently being indexed.
- Updated the supply logic to save denoms that are not yet stored in the database, removing the need for hardcoding.
- Fixed the StakedSuppliersByBlockAndService and StakedAppsByBlockAndService reports.

## Issue

Previously, we were using the query client provided by subql via the `api` field injected globally, but this client only allowed querying data from the latest block, not from the block being indexed. To address this, we now create a custom query client and specify the height of the block being indexed.

Another issue affected the StakedSuppliersByBlockAndService and StakedAppsByBlockAndService reports: they were not including data from the first service, which led to incomplete results.

## Type of change

Select one or more:

- [ ] New feature, functionality or library
- [x] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## Sanity Checklist

- [x] I have tested my changes using the available tooling
- [x] I have commented my code
- [x] I have performed a self-review of my own code; both comments & source code
- [ ] I create and reference any new tickets, if applicable
- [ ] I have left TODOs throughout the codebase, if applicable
