### PR TITLE
Added migration support

### DIFF
--- a/project.ts
+++ b/project.ts
@@ -386,15 +386,37 @@ const project: CosmosProject = {
           ],
         },
       ],
+      // --- MIGRATION
+      [
+        "pocket.migration_events",
+        {
+          file: "./proto/pocket/migration/event.proto",
+          messages: [
+            "EventImportMorseClaimableAccounts",
+            "EventMorseAccountClaimed",
+            "EventMorseApplicationClaimed",
+            "EventMorseSupplierClaimed",
+          ],
+        },
+      ],
+      [
+        "pocket.migration_tx",
+        {
+          file: "./proto/pocket/migration/tx.proto",
+          messages: [
+            "MsgImportMorseClaimableAccounts",
+            "MsgClaimMorseAccount",
+            "MsgClaimMorseApplication",
+            "MsgClaimMorseSupplier",
+          ],
+        },
+      ],
     ]),
   },
   dataSources: [
     {
       startBlock: 1,
-      // startBlock: 349, // first set of txs
-      // startBlock: 34123, // first set of claims
-      // startBlock: 55330, // damn big block 176k events
-      // startBlock: 58120, // more than 570 mb in response
+      // migration at 25507 on alpha
       kind: CosmosDatasourceKind.Runtime,
       mapping: {
         file: "./dist/index.js",

--- a/proto/pocket/application/tx.proto
+++ b/proto/pocket/application/tx.proto
@@ -55,7 +55,7 @@ message MsgStakeApplication {
   cosmos.base.v1beta1.Coin                 stake = 2; // The total amount of uPOKT the application has staked. Must be ≥ to the current amount that the application has staked (if any)
   repeated pocket.shared.ApplicationServiceConfig services = 3; // The list of services this application is staked to request service for
 
-  // TODO_POST_MAINNET_CONSIDERATION: Consider allowing applications to delegate
+  // TODO_POST_MAINNET: Consider allowing applications to delegate
   // to gateways at time of staking for a better developer experience.
   // repeated string gateway_address
 }

--- a/proto/pocket/application/types.proto
+++ b/proto/pocket/application/types.proto
@@ -30,7 +30,7 @@ message Application {
   //   - https://www.notion.so/buildwithgrove/Off-chain-Application-Stake-Tracking-6a8bebb107db4f7f9dc62cbe7ba555f7
   repeated pocket.shared.ApplicationServiceConfig service_configs = 3;
 
-  // TODO_BETA(@bryanchriswhite): Rename `delegatee_gateway_addresses` to `gateway_addresses_delegated_to`.
+  // TODO_MAINNET_MIGRATION(@bryanchriswhite): Rename `delegatee_gateway_addresses` to `gateway_addresses_delegated_to`.
   // Ensure to rename all relevant configs, comments, variables, function names, etc as well.
   // Non-nullable list of Bech32 encoded delegatee Gateway addresses
   repeated string delegatee_gateway_addresses = 4 [(cosmos_proto.scalar) = "cosmos.AddressString", (gogoproto.nullable) = false];

--- a/proto/pocket/migration/morse_offchain.proto
+++ b/proto/pocket/migration/morse_offchain.proto
@@ -16,7 +16,7 @@ syntax = "proto3";
 //
 // These types are used by the migration subcommand to transform
 // the Morse state export into the Shannon state import like so:
-//  $ pocketd migrate collect-morse-accounts ...
+//  $ pocketd tx migration collect-morse-accounts ...
 //
 // CRITICAL: These types are offchain and ARE NOT persisted onchain (Shannon) at any point.
 package pocket.migration;
@@ -98,11 +98,11 @@ message MorseApplication {
   bytes address = 1 [(gogoproto.casttype) = "github.com/cometbft/cometbft/crypto.Address", (gogoproto.jsontag) = "address", (gogoproto.moretags) = "yaml:\"address\""];
   // PublicKey is the binary representation of a Morse application's ed25519 public key.
   bytes public_key = 2 [(gogoproto.jsontag) = "public_key", (gogoproto.moretags) = "yaml:\"public_key\""];
-  // TODO_MAINNET(@Olshansk):  Should status and/or jailed be considered during the migration, and if so, how?
+  // TODO_MAINNET_MIGRATION(@Olshansk):  Should status and/or jailed be considered during the migration, and if so, how?
   bool   jailed = 3[(gogoproto.jsontag) = "jailed", (gogoproto.moretags) = "yaml:\"jailed\""];
   int32  status = 4 [(gogoproto.jsontag) = "status", (gogoproto.moretags) = "yaml:\"status\""];
   // The string representation of the BigInt amount of upokt.
-  string staked_tokens = 6 [(gogoproto.jsontag) = "tokens"];
+  string staked_tokens = 6 [(gogoproto.jsontag) = "staked_tokens"];
 }
 
 // MorseValidator is a subset of the Morse ProtoValidator type.
@@ -118,7 +118,7 @@ message MorseValidator {
   bytes address = 1 [(gogoproto.casttype) = "github.com/cometbft/cometbft/crypto.Address", (gogoproto.moretags) = "yaml:\"address\"", (gogoproto.jsontag) = "address"];
   // The binary representation of a Morse application's ed25519 public key.
   bytes public_key = 2 [(gogoproto.moretags) = "yaml:\"public_key\"", (gogoproto.jsontag) = "public_key"];
-  // TODO_MAINNET(@Olshansk):  Should status and/or jailed be considered during the migration, and if so, how?
+  // TODO_MAINNET_MIGRATION(@Olshansk):  Should status and/or jailed be considered during the migration, and if so, how?
   bool jailed = 3 [(gogoproto.jsontag) = "jailed"];
   int32 status = 4 [(gogoproto.jsontag) = "status"];
   // The string representation of the BigInt amount of upokt.

--- a/proto/pocket/migration/morse_onchain.proto
+++ b/proto/pocket/migration/morse_onchain.proto
@@ -29,8 +29,12 @@ message MorseClaimableAccount {
   // The hex-encoded address of the Morse account whose balance will be claimed.
   string morse_src_address = 2 [(gogoproto.jsontag) = "morse_src_address"];
 
+  // DEV_NOTE: This field was momentarily used to hold the Morse public key; however, an
+  // optimization eliminates the need for this. Reserved for backwards compatibility.
+  //
   // The ed25519 public key of the account.
-  bytes public_key = 4 [(gogoproto.casttype) = "crypto/ed25519.PublicKey"];
+  // bytes public_key = 4 [(gogoproto.casttype) = "crypto/ed25519.PublicKey"];
+  reserved 4;
 
   // The unstaked upokt tokens (i.e. account balance) available for claiming.
   cosmos.base.v1beta1.Coin unstaked_balance = 5 [(gogoproto.nullable) = false, (gogoproto.jsontag) = "unstaked_balance"];

--- a/proto/pocket/migration/params.proto
+++ b/proto/pocket/migration/params.proto
@@ -11,4 +11,10 @@ option (gogoproto.stable_marshaler_all) = true;
 message Params {
   option (amino.name) = "pocket/x/migration/Params";
   option (gogoproto.equal) = true;
+
+  // waive_morse_claim_gas_fees is a feature flag used to enable/disable the waiving of gas fees for txs that:
+  // - Contain exactly one secp256k1 signer
+  // - Contain at least one Morse account/actor claim messages
+  // - Do not contain any other messages other than Morse account/actor claim messages
+  bool waive_morse_claim_gas_fees = 1 [(gogoproto.jsontag) = "waive_morse_claim_gas_fees", (gogoproto.moretags) = "yaml:\"waive_morse_claim_gas_fees\""];
 }

--- a/proto/pocket/migration/tx.proto
+++ b/proto/pocket/migration/tx.proto
@@ -40,6 +40,8 @@ message MsgUpdateParams {
 
   // NOTE: All parameters must be supplied.
   Params params = 2 [(gogoproto.nullable) = false, (amino.dont_omitempty) = true];
+
+  // Next free index: 3
 }
 
 // MsgUpdateParamsResponse defines the response structure for executing a
@@ -53,20 +55,22 @@ message MsgImportMorseClaimableAccounts {
   // authority is the address that controls the module (defaults to x/gov unless overwritten).
   string authority = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"];
 
-  // the account state derived from the Morse state export and the `pocketd migrate collect-morse-accounts` command.
+  // the account state derived from the Morse state export and the `pocketd tx migration collect-morse-accounts` command.
   MorseAccountState morse_account_state = 2 [(gogoproto.jsontag) = "morse_account_state", (gogoproto.nullable) = false];
 
   // Validates the morse_account_state sha256 hash:
   // - Transaction fails if hash doesn't match on-chain computation
   // - Off-chain social consensus should be reached off-chain before verification
 
-  // Verification can be done by comparing with locally derived Morse state like so:
-  //   $ pocketd migrate collect-morse-accounts $<(pocket util export-genesis-for-reset)
+  // Verification can be done by comparing with locally derived Morse state like so (at a high-level):
+  //   $ pocketd tx migration collect-morse-accounts $<(pocket util export-genesis-for-reset)
 
   // Additional documentation:
   // - pocket util export-genesis-for-migration --help
-  // - pocketd migrate collect-morse-accounts --help
+  // - pocketd tx migration collect-morse-accounts --help
   bytes morse_account_state_hash = 3 [(gogoproto.jsontag) = "morse_account_state_hash"];
+
+  // Next free index: 4
 }
 
 // MsgImportMorseClaimableAccountsResponse is returned from MsgImportMorseClaimableAccounts.
@@ -78,6 +82,8 @@ message MsgImportMorseClaimableAccountsResponse {
 
   // Number of claimable accounts (EOAs) collected from Morse state export.
   uint64 num_accounts = 2 [(gogoproto.jsontag) = "num_accounts"];
+
+  // Next free index: 3
 }
 
 // MsgClaimMorseAccount is used to execute a claim (one-time minting of tokens on Shannon),
@@ -88,25 +94,40 @@ message MsgImportMorseClaimableAccountsResponse {
 // - The Shannon account specified must be the message signer
 // - Authz grants MAY be used to delegate claiming authority to other Shannon accounts
 message MsgClaimMorseAccount {
-  option (cosmos.msg.v1.signer) = "shannon_dest_address";
+  option (cosmos.msg.v1.signer) = "shannon_signing_address";
+
+  // The bech32-encoded address of the Shannon account which is signing for this message.
+  // This account is liable for any fees incurred by violating the constraints of Morse
+  // account/actor claim message fee waiving; the tx contains ONE OR MORE Morse account/actor
+  // claim messages AND has EXACTLY ONE signer.
+  string shannon_signing_address = 4 [(cosmos_proto.scalar) = "cosmos.AddressString", (gogoproto.jsontag) = "shannon_signing_address"];
 
   // The bech32-encoded address of the Shannon account to which the claimed balance will be minted.
   string shannon_dest_address = 1 [(cosmos_proto.scalar) = "cosmos.AddressString", (gogoproto.jsontag) = "shannon_dest_address"];
 
+  // DEV_NOTE: This field was momentarily used to hold the Morse source
+  // address; however, an optimization eliminates the need for this.
+  // Reserved for backwards compatibility.
+  //
   // The hex-encoded address of the Morse account whose balance will be claimed.
   // E.g.: 00f9900606fa3d5c9179fc0c8513078a53a2073e
-  string morse_src_address = 2 [(gogoproto.jsontag) = "morse_src_address"];
+  // string morse_src_address = 2 [(gogoproto.jsontag) = "morse_src_address"];
+  reserved 2;
+
+  // The ed25519 public key of the morse account with morse_src_address.
+  bytes morse_public_key = 5 [(gogoproto.casttype) = "github.com/cometbft/cometbft/crypto/ed25519.PubKey"];
 
   // The hex-encoded signature, by the Morse account, of this message (where this field is nil).
   // I.e.: morse_signature = private_key.sign(marshal(MsgClaimMorseAccount{morse_signature: nil, ...}))
   bytes morse_signature = 3 [(gogoproto.jsontag) = "morse_signature"];
+
+  // Next free index: 6
 }
 
 // MsgClaimMorseAccountResponse is returned from MsgClaimMorseAccount.
 // It indicates the morse_src_address of the account which was claimed, the total
 // balance claimed, and the height at which the claim was committed.
 message MsgClaimMorseAccountResponse {
-
   // The hex-encoded address of the Morse account whose balance will be claimed.
   // E.g.: 00f9900606fa3d5c9179fc0c8513078a53a2073e
   string morse_src_address = 1 [(gogoproto.jsontag) = "morse_src_address"];
@@ -116,6 +137,8 @@ message MsgClaimMorseAccountResponse {
 
   // The session end height (on Shannon) in which the claim was committed (i.e. claimed).
   int64 session_end_height = 3 [(gogoproto.jsontag) = "session_end_height"];
+
+  // Next free index: 4
 }
 
 // MsgClaimMorseApplication is used to execute a claim (one-time minting of tokens on Shannon),
@@ -123,16 +146,29 @@ message MsgClaimMorseAccountResponse {
 // to the balance of the given Shannon account, followed by staking that Shannon account as an application
 // for the given service_config and the same stake amount as on Morse.
 message MsgClaimMorseApplication {
-  option (cosmos.msg.v1.signer) = "shannon_dest_address";
+  option (cosmos.msg.v1.signer) = "shannon_signing_address";
+
+  // The bech32-encoded address of the Shannon account which is signing for this message.
+  // This account is liable for any fees incurred by violating the constraints of Morse
+  // account/actor claim message fee waiving; the tx contains ONE OR MORE Morse account/actor
+  // claim messages AND has EXACTLY ONE signer.
+  string shannon_signing_address = 5 [(cosmos_proto.scalar) = "cosmos.AddressString", (gogoproto.jsontag) = "shannon_signing_address"];
 
   // The bech32-encoded address of the Shannon account to which the claimed tokens
   // will be minted and from which the application will be staked.
   string shannon_dest_address = 1 [(cosmos_proto.scalar) = "cosmos.AddressString", (gogoproto.jsontag) = "shannon_dest_address"];
 
+  // DEV_NOTE: This field was momentarily used to hold the Morse source
+  // address; however, an optimization eliminates the need for this.
+  // Reserved for backwards compatibility.
+  //
   // The hex-encoded address of the Morse account whose balance will be claimed.
   // E.g.: 00f9900606fa3d5c9179fc0c8513078a53a2073e
+  // string morse_src_address = 2 [(gogoproto.jsontag) = "morse_src_address"];
+  reserved 2;
 
-  string morse_src_address = 2 [(gogoproto.jsontag) = "morse_src_address"];
+  // The ed25519 public key of the morse account with morse_src_address.
+  bytes morse_public_key = 6 [(gogoproto.casttype) = "github.com/cometbft/cometbft/crypto/ed25519.PubKey"];
 
   // The hex-encoded signature, by the Morse account, of this message (where this field is nil).
   // I.e.: morse_signature = private_key.sign(marshal(MsgClaimMorseAccount{morse_signature: nil, ...}))
@@ -142,6 +178,8 @@ message MsgClaimMorseApplication {
   // NOTE: This is not a repeated field, as in MsgStakeApplication,
   // because an application can only be staked for one service.
   shared.ApplicationServiceConfig service_config = 4 [(gogoproto.jsontag) = "service_config"];
+
+  // Next free index: 7
 }
 
 // MsgClaimMorseApplicationResponse is returned from MsgClaimMorseApplication.
@@ -164,6 +202,8 @@ message MsgClaimMorseApplicationResponse {
 
   // The application which was staked as a result of the claim.
   application.Application application = 5 [(gogoproto.jsontag) = "application"];
+
+  // Next free index: 6
 }
 
 // MsgClaimMorseSupplier is used to:
@@ -175,7 +215,13 @@ message MsgClaimMorseApplicationResponse {
 // NOTE: The supplier module's staking fee parameter (at the time of claiming) is deducted from the
 // claimed balance.
 message MsgClaimMorseSupplier {
-  option (cosmos.msg.v1.signer) = "shannon_owner_address";
+  option (cosmos.msg.v1.signer) = "shannon_signing_address";
+
+  // The bech32-encoded address of the Shannon account which is signing for this message.
+  // This account is liable for any fees incurred by violating the constraints of Morse
+  // account/actor claim message fee waiving; the tx contains ONE OR MORE Morse account/actor
+  // claim messages AND has EXACTLY ONE signer.
+  string shannon_signing_address = 6 [(cosmos_proto.scalar) = "cosmos.AddressString", (gogoproto.jsontag) = "shannon_signing_address"];
 
   // The bech32-encoded address of the Shannon account to which the claimed tokens
   // will be minted and which become the supplier owner.
@@ -187,11 +233,17 @@ message MsgClaimMorseSupplier {
   // See: https://dev.poktroll.com/operate/configs/supplier_staking_config#staking-types.
   string shannon_operator_address = 2 [(cosmos_proto.scalar) = "cosmos.AddressString", (gogoproto.jsontag) = "shannon_operator_address"];
 
+  // The ed25519 public key of the morse account with morse_src_address.
+  bytes morse_public_key = 7 [(gogoproto.casttype) = "github.com/cometbft/cometbft/crypto/ed25519.PubKey"];
+
+  // DEV_NOTE: This field was momentarily used to hold the Morse source
+  // address; however, an optimization eliminates the need for this.
+  // Reserved for backwards compatibility.
+  //
   // The hex-encoded address of the Morse account whose balance will be claimed.
   // E.g.: 00f9900606fa3d5c9179fc0c8513078a53a2073e
-  //
-  // TODO_MAINNET(@bryanchriswhite, #1126): Rename to `morse_src_owner_address`.
-  string morse_src_address = 3 [(gogoproto.jsontag) = "morse_src_address"];
+  // string morse_src_address = 3 [(gogoproto.jsontag) = "morse_src_address"];
+  reserved 3;
 
   // The hex-encoded signature, by the Morse account, of this message (where this field is nil).
   // I.e.: morse_signature = private_key.sign(marshal(MsgClaimMorseAccount{morse_signature: nil, ...}))
@@ -201,6 +253,8 @@ message MsgClaimMorseSupplier {
 
   // The services this supplier is staked to provide service for.
   repeated shared.SupplierServiceConfig services = 5 [(gogoproto.jsontag) = "services"];
+
+  // Next free index: 8
 }
 
 // MsgClaimMorseSupplierResponse is returned from MsgClaimMorseSupplier.
@@ -224,5 +278,7 @@ message MsgClaimMorseSupplierResponse {
 
   // The supplier which was staked as a result of the claim.
   shared.Supplier supplier = 5 [(gogoproto.jsontag) = "supplier"];
+
+  // Next free index: 6
 }
 

--- a/proto/pocket/proof/params.proto
+++ b/proto/pocket/proof/params.proto
@@ -22,20 +22,20 @@ message Params {
   // is equal to or above the threshold. This is in contrast to the this requirement
   // being determined probabilistically via ProofRequestProbability.
   //
-  // TODO_MAINNET: Consider renaming this to `proof_requirement_threshold_upokt`.
+  // TODO_MAINNET_MIGRATION: Consider renaming this to `proof_requirement_threshold_upokt`.
   cosmos.base.v1beta1.Coin proof_requirement_threshold = 3 [(gogoproto.jsontag) = "proof_requirement_threshold"];
 
   // proof_missing_penalty is the number of tokens (uPOKT) which should be slashed from a supplier
   // when a proof is required (either via proof_requirement_threshold or proof_missing_penalty)
   // but is not provided.
-  // TODO_MAINNET: Consider renaming this to `proof_missing_penalty_upokt`.
+  // TODO_MAINNET_MIGRATION: Consider renaming this to `proof_missing_penalty_upokt`.
   cosmos.base.v1beta1.Coin proof_missing_penalty = 4 [(gogoproto.jsontag) = "proof_missing_penalty"];
 
   // proof_submission_fee is the number of tokens (uPOKT) which should be paid by
   // the supplier operator when submitting a proof.
   // This is needed to account for the cost of storing proofs onchain and prevent
   // spamming (i.e. sybil bloat attacks) the network with non-required proofs.
-  // TODO_MAINNET: Consider renaming this to `proof_submission_fee_upokt`.
+  // TODO_MAINNET_MIGRATION: Consider renaming this to `proof_submission_fee_upokt`.
   cosmos.base.v1beta1.Coin proof_submission_fee = 5 [(gogoproto.jsontag) = "proof_submission_fee"];
 
   // IMPORTANT: Make sure to update all related files if you're modifying or adding a new parameter.

--- a/proto/pocket/proof/types.proto
+++ b/proto/pocket/proof/types.proto
@@ -57,3 +57,18 @@ enum ClaimProofStatus {
   VALIDATED = 1;
   INVALID = 2;
 }
+
+// **************
+// OFFCHAIN TYPES
+// The messages defined below are used for offchain logic and should not be used for any onchain logic.
+// They are defined in the same file as the onchain types for convenience.
+// **************
+
+// SessionSMT is the serializable session's SMST used to persist the session's
+// state offchain by the RelayMiner.
+// It is not used for any onchain logic.
+message SessionSMT {
+  pocket.session.SessionHeader session_header = 1;
+  string supplier_operator_address = 2 [(cosmos_proto.scalar) = "cosmos.AddressString"];
+  bytes smt_root = 3;
+}

--- a/proto/pocket/session/params.proto
+++ b/proto/pocket/session/params.proto
@@ -1,11 +1,11 @@
 syntax = "proto3";
 package pocket.session;
 
-option go_package = "github.com/pokt-network/poktroll/x/session/types";
-option (gogoproto.stable_marshaler_all) = true;
-
 import "amino/amino.proto";
 import "gogoproto/gogo.proto";
+
+option go_package = "github.com/pokt-network/poktroll/x/session/types";
+option (gogoproto.stable_marshaler_all) = true;
 
 // Params defines the parameters for the module.
 message Params {

--- a/proto/pocket/shared/service.proto
+++ b/proto/pocket/shared/service.proto
@@ -15,12 +15,12 @@ message Service {
   // For example, what if we want to request a session for a certain service but with some additional configs that identify it?
   string id = 1; // Unique identifier for the service
 
-  // TODO_BETA(@bryanchriswhite): Either remove this or rename it to alias.
-  string name = 2; // (Optional) Semantic human readable name for the service
+  // TODO_POST_MAINNET: Rename service.name to service.description
+  string name = 2; // (Optional) Human readable description of the service
 
   // The cost of a single relay for this service in terms of compute units.
-  // Must be used alongside the global 'compute_units_to_tokens_multipler' to calculate the cost of a relay for this service.
-  // cost_per_relay_for_specific_service = compute_units_per_relay_for_specific_service * compute_units_to_tokens_multipler_global_value
+  // Must be used alongside the global 'compute_units_to_tokens_multiplier' to calculate the cost of a relay for this service.
+  // cost_per_relay_for_specific_service = compute_units_per_relay_for_specific_service * compute_units_to_tokens_multiplier_global_value
   uint64 compute_units_per_relay = 3; // Compute units required per relay for this service
 
   // The owner address that created the service.
@@ -34,7 +34,7 @@ message Service {
 message ApplicationServiceConfig {
   string service_id = 1; // The Service ID for which the application is configured
 
-  // TODO_MAINNET: There is an opportunity for applications to advertise the max
+  // TODO_POST_MAINNET: There is an opportunity for applications to advertise the max
   // they're willing to pay for a certain configuration/price, but this is outside of scope.
   // RPCConfig rpc_configs = 2; // List of endpoints for the service
 }
@@ -44,7 +44,7 @@ message SupplierServiceConfig {
   string service_id = 1; // The Service ID for which the supplier is configured
   repeated SupplierEndpoint endpoints = 2; // List of endpoints for the service
   repeated ServiceRevenueShare rev_share = 3; // List of revenue share configurations for the service
-  // TODO_MAINNET: There is an opportunity for supplier to advertise the min
+  // TODO_POST_MAINNET: There is an opportunity for supplier to advertise the min
   // they're willing to earn for a certain configuration/price, but this is outside of scope.
 }
 

--- a/schema.graphql
+++ b/schema.graphql
@@ -1124,3 +1124,108 @@ type BlockSupply @entity {
   block: Block!
   supply: Supply!
 }
+
+# --- MIGRATION ---
+
+type MsgImportMorseClaimableAccounts @entity {
+  id: ID!
+  authority: Account!
+  morseAccountStateHash: String!
+  block: Block!
+  message: Message!
+  transaction: Transaction!
+  morseClaimableAccounts: [MorseClaimableAccount] @derivedFrom(field: "msgImportMorseClaimableAccounts")
+}
+
+type MorseClaimableAccount @entity {
+  # the id is the morse_src_address
+  id: ID!
+  msgImportMorseClaimableAccounts: MsgImportMorseClaimableAccounts!
+  unstakedBalanceAmount: BigInt!
+  supplierStakeAmount: BigInt!
+  applicationStakeAmount: BigInt!
+
+  # to be filled when claiming
+  shannonDestAddress: String
+  claimedAtHeight: BigInt
+  claimed: Boolean!
+
+  # TODO(@Alann27): the denominations are really needed? We know for sure that they are upokt
+  unstakedBalanceDenom: String!
+  supplierStakeDenom: String!
+  applicationStakeDenom: String!
+}
+
+type MsgClaimMorseAccount @entity {
+  id: ID!
+  account: Account!
+  shannonSigningAddress: String!
+  shannonDestAddress: String!
+  morsePublicKey: String!
+  morseSrcAddress: String!
+  morseSignature: String!
+  # Retrieved from the event
+  balanceAmount: BigInt!
+  balanceDenom: String!
+  # ---
+  block: Block!
+  transaction: Transaction!
+  message: Message!
+}
+
+type MsgClaimMorseApplication @entity {
+  id: ID!
+  application: Application!
+  shannonSigningAddress: String!
+  shannonDestAddress: String!
+  morsePublicKey: String!
+  morseSrcAddress: String!
+  morseSignature: String!
+  # Retrieved from the event
+  stakeAmount: BigInt!
+  stakeDenom: String!
+  balanceAmount: BigInt!
+  balanceDenom: String!
+  # ---
+  block: Block!
+  transaction: Transaction!
+  message: Message!
+  serviceConfigs: [MsgClaimMorseApplicationService] @derivedFrom(field: "claimMsg")
+}
+
+# Many to man
+type MsgClaimMorseApplicationService @entity {
+  id: ID!
+  claimMsg: MsgClaimMorseApplication!
+  service: Service!
+}
+
+type MsgClaimMorseSupplier @entity {
+  id: ID!
+  supplier: Supplier!
+  shannonSigningAddress: String!
+  shannonOwnerAddress: String!
+  shannonOperatorAddress: String!
+  morsePublicKey: String!
+  morseSrcAddress: String!
+  morseSignature: String!
+  # Retrieved from the event
+  stakeAmount: BigInt!
+  stakeDenom: String!
+  balanceAmount: BigInt!
+  balanceDenom: String!
+  # ---
+  block: Block!
+  transaction: Transaction!
+  message: Message!
+  serviceConfigs: [MsgClaimMorseSupplierService] @derivedFrom(field: "claimMsg")
+}
+
+type MsgClaimMorseSupplierService @entity {
+  id: ID!
+  claimMsg: MsgClaimMorseSupplier!
+  service: Service!
+  revShare: [SupplierRevShare]!
+  endpoints: [SupplierEndpoint]!
+}
+

--- a/src/client/google/api/http.ts
+++ b/src/client/google/api/http.ts
@@ -33,7 +33,7 @@ export interface Http {
 }
 
 /**
- * # gRPC Transcoding
+ * gRPC Transcoding
  *
  * gRPC Transcoding is a feature for mapping between a gRPC method and one or
  * more HTTP REST endpoints. It allows developers to build a single API service
@@ -74,9 +74,8 @@ export interface Http {
  *
  * This enables an HTTP REST to gRPC mapping as below:
  *
- * HTTP | gRPC
- * -----|-----
- * `GET /v1/messages/123456`  | `GetMessage(name: "messages/123456")`
+ * - HTTP: `GET /v1/messages/123456`
+ * - gRPC: `GetMessage(name: "messages/123456")`
  *
  * Any fields in the request message which are not bound by the path template
  * automatically become HTTP query parameters if there is no HTTP request body.
@@ -100,11 +99,9 @@ export interface Http {
  *
  * This enables a HTTP JSON to RPC mapping as below:
  *
- * HTTP | gRPC
- * -----|-----
- * `GET /v1/messages/123456?revision=2&sub.subfield=foo` |
- * `GetMessage(message_id: "123456" revision: 2 sub: SubMessage(subfield:
- * "foo"))`
+ * - HTTP: `GET /v1/messages/123456?revision=2&sub.subfield=foo`
+ * - gRPC: `GetMessage(message_id: "123456" revision: 2 sub:
+ * SubMessage(subfield: "foo"))`
  *
  * Note that fields which are mapped to URL query parameters must have a
  * primitive type or a repeated primitive type or a non-repeated message type.
@@ -134,10 +131,8 @@ export interface Http {
  * representation of the JSON in the request body is determined by
  * protos JSON encoding:
  *
- * HTTP | gRPC
- * -----|-----
- * `PATCH /v1/messages/123456 { "text": "Hi!" }` | `UpdateMessage(message_id:
- * "123456" message { text: "Hi!" })`
+ * - HTTP: `PATCH /v1/messages/123456 { "text": "Hi!" }`
+ * - gRPC: `UpdateMessage(message_id: "123456" message { text: "Hi!" })`
  *
  * The special name `*` can be used in the body mapping to define that
  * every field not bound by the path template should be mapped to the
@@ -159,10 +154,8 @@ export interface Http {
  *
  * The following HTTP JSON to RPC mapping is enabled:
  *
- * HTTP | gRPC
- * -----|-----
- * `PATCH /v1/messages/123456 { "text": "Hi!" }` | `UpdateMessage(message_id:
- * "123456" text: "Hi!")`
+ * - HTTP: `PATCH /v1/messages/123456 { "text": "Hi!" }`
+ * - gRPC: `UpdateMessage(message_id: "123456" text: "Hi!")`
  *
  * Note that when using `*` in the body mapping, it is not possible to
  * have HTTP parameters, as all fields not bound by the path end in
@@ -190,29 +183,32 @@ export interface Http {
  *
  * This enables the following two alternative HTTP JSON to RPC mappings:
  *
- * HTTP | gRPC
- * -----|-----
- * `GET /v1/messages/123456` | `GetMessage(message_id: "123456")`
- * `GET /v1/users/me/messages/123456` | `GetMessage(user_id: "me" message_id:
- * "123456")`
+ * - HTTP: `GET /v1/messages/123456`
+ * - gRPC: `GetMessage(message_id: "123456")`
  *
- * ## Rules for HTTP mapping
+ * - HTTP: `GET /v1/users/me/messages/123456`
+ * - gRPC: `GetMessage(user_id: "me" message_id: "123456")`
+ *
+ * Rules for HTTP mapping
  *
  * 1. Leaf request fields (recursive expansion nested messages in the request
  *    message) are classified into three categories:
  *    - Fields referred by the path template. They are passed via the URL path.
- *    - Fields referred by the [HttpRule.body][google.api.HttpRule.body]. They are passed via the HTTP
+ *    - Fields referred by the [HttpRule.body][google.api.HttpRule.body]. They
+ *    are passed via the HTTP
  *      request body.
  *    - All other fields are passed via the URL query parameters, and the
  *      parameter name is the field path in the request message. A repeated
  *      field can be represented as multiple query parameters under the same
  *      name.
- *  2. If [HttpRule.body][google.api.HttpRule.body] is "*", there is no URL query parameter, all fields
+ *  2. If [HttpRule.body][google.api.HttpRule.body] is "*", there is no URL
+ *  query parameter, all fields
  *     are passed via URL path and HTTP request body.
- *  3. If [HttpRule.body][google.api.HttpRule.body] is omitted, there is no HTTP request body, all
+ *  3. If [HttpRule.body][google.api.HttpRule.body] is omitted, there is no HTTP
+ *  request body, all
  *     fields are passed via URL path and URL query parameters.
  *
- * ### Path template syntax
+ * Path template syntax
  *
  *     Template = "/" Segments [ Verb ] ;
  *     Segments = Segment { "/" Segment } ;
@@ -251,7 +247,7 @@ export interface Http {
  * Document](https://developers.google.com/discovery/v1/reference/apis) as
  * `{+var}`.
  *
- * ## Using gRPC API Service Configuration
+ * Using gRPC API Service Configuration
  *
  * gRPC API Service Configuration (service config) is a configuration language
  * for configuring a gRPC service to become a user-facing product. The
@@ -266,15 +262,14 @@ export interface Http {
  * specified in the service config will override any matching transcoding
  * configuration in the proto.
  *
- * Example:
+ * The following example selects a gRPC method and applies an `HttpRule` to it:
  *
  *     http:
  *       rules:
- *         # Selects a gRPC method and applies HttpRule to it.
  *         - selector: example.v1.Messaging.GetMessage
  *           get: /v1/messages/{message_id}/{sub.subfield}
  *
- * ## Special notes
+ * Special notes
  *
  * When gRPC Transcoding is used to map a gRPC to JSON REST endpoints, the
  * proto to JSON conversion must follow the [proto3
@@ -306,7 +301,8 @@ export interface HttpRule {
   /**
    * Selects a method to which this rule applies.
    *
-   * Refer to [selector][google.api.DocumentationRule.selector] for syntax details.
+   * Refer to [selector][google.api.DocumentationRule.selector] for syntax
+   * details.
    */
   selector: string;
   /**

--- a/src/client/pocket/application/types.ts
+++ b/src/client/pocket/application/types.ts
@@ -29,7 +29,7 @@ export interface Application {
    */
   serviceConfigs: ApplicationServiceConfig[];
   /**
-   * TODO_BETA(@bryanchriswhite): Rename `delegatee_gateway_addresses` to `gateway_addresses_delegated_to`.
+   * TODO_MAINNET_MIGRATION(@bryanchriswhite): Rename `delegatee_gateway_addresses` to `gateway_addresses_delegated_to`.
    * Ensure to rename all relevant configs, comments, variables, function names, etc as well.
    * Non-nullable list of Bech32 encoded delegatee Gateway addresses
    */

--- a/src/client/pocket/migration/morse_offchain.ts
+++ b/src/client/pocket/migration/morse_offchain.ts
@@ -91,7 +91,7 @@ export interface MorseApplication {
   address: Uint8Array;
   /** PublicKey is the binary representation of a Morse application's ed25519 public key. */
   publicKey: Uint8Array;
-  /** TODO_MAINNET(@Olshansk):  Should status and/or jailed be considered during the migration, and if so, how? */
+  /** TODO_MAINNET_MIGRATION(@Olshansk):  Should status and/or jailed be considered during the migration, and if so, how? */
   jailed: boolean;
   status: number;
   /** The string representation of the BigInt amount of upokt. */
@@ -109,7 +109,7 @@ export interface MorseValidator {
   address: Uint8Array;
   /** The binary representation of a Morse application's ed25519 public key. */
   publicKey: Uint8Array;
-  /** TODO_MAINNET(@Olshansk):  Should status and/or jailed be considered during the migration, and if so, how? */
+  /** TODO_MAINNET_MIGRATION(@Olshansk):  Should status and/or jailed be considered during the migration, and if so, how? */
   jailed: boolean;
   status: number;
   /** The string representation of the BigInt amount of upokt. */

--- a/src/client/pocket/migration/morse_onchain.ts
+++ b/src/client/pocket/migration/morse_onchain.ts
@@ -34,8 +34,6 @@ export interface MorseClaimableAccount {
   shannonDestAddress: string;
   /** The hex-encoded address of the Morse account whose balance will be claimed. */
   morseSrcAddress: string;
-  /** The ed25519 public key of the account. */
-  publicKey: Uint8Array;
   /** The unstaked upokt tokens (i.e. account balance) available for claiming. */
   unstakedBalance:
     | Coin
@@ -129,7 +127,6 @@ function createBaseMorseClaimableAccount(): MorseClaimableAccount {
   return {
     shannonDestAddress: "",
     morseSrcAddress: "",
-    publicKey: new Uint8Array(0),
     unstakedBalance: undefined,
     supplierStake: undefined,
     applicationStake: undefined,
@@ -144,9 +141,6 @@ export const MorseClaimableAccount: MessageFns<MorseClaimableAccount> = {
     }
     if (message.morseSrcAddress !== "") {
       writer.uint32(18).string(message.morseSrcAddress);
-    }
-    if (message.publicKey.length !== 0) {
-      writer.uint32(34).bytes(message.publicKey);
     }
     if (message.unstakedBalance !== undefined) {
       Coin.encode(message.unstakedBalance, writer.uint32(42).fork()).join();
@@ -184,14 +178,6 @@ export const MorseClaimableAccount: MessageFns<MorseClaimableAccount> = {
           }
 
           message.morseSrcAddress = reader.string();
-          continue;
-        }
-        case 4: {
-          if (tag !== 34) {
-            break;
-          }
-
-          message.publicKey = reader.bytes();
           continue;
         }
         case 5: {
@@ -239,7 +225,6 @@ export const MorseClaimableAccount: MessageFns<MorseClaimableAccount> = {
     return {
       shannonDestAddress: isSet(object.shannonDestAddress) ? globalThis.String(object.shannonDestAddress) : "",
       morseSrcAddress: isSet(object.morseSrcAddress) ? globalThis.String(object.morseSrcAddress) : "",
-      publicKey: isSet(object.publicKey) ? bytesFromBase64(object.publicKey) : new Uint8Array(0),
       unstakedBalance: isSet(object.unstakedBalance) ? Coin.fromJSON(object.unstakedBalance) : undefined,
       supplierStake: isSet(object.supplierStake) ? Coin.fromJSON(object.supplierStake) : undefined,
       applicationStake: isSet(object.applicationStake) ? Coin.fromJSON(object.applicationStake) : undefined,
@@ -254,9 +239,6 @@ export const MorseClaimableAccount: MessageFns<MorseClaimableAccount> = {
     }
     if (message.morseSrcAddress !== "") {
       obj.morseSrcAddress = message.morseSrcAddress;
-    }
-    if (message.publicKey.length !== 0) {
-      obj.publicKey = base64FromBytes(message.publicKey);
     }
     if (message.unstakedBalance !== undefined) {
       obj.unstakedBalance = Coin.toJSON(message.unstakedBalance);
@@ -280,7 +262,6 @@ export const MorseClaimableAccount: MessageFns<MorseClaimableAccount> = {
     const message = createBaseMorseClaimableAccount();
     message.shannonDestAddress = object.shannonDestAddress ?? "";
     message.morseSrcAddress = object.morseSrcAddress ?? "";
-    message.publicKey = object.publicKey ?? new Uint8Array(0);
     message.unstakedBalance = (object.unstakedBalance !== undefined && object.unstakedBalance !== null)
       ? Coin.fromPartial(object.unstakedBalance)
       : undefined;
@@ -294,31 +275,6 @@ export const MorseClaimableAccount: MessageFns<MorseClaimableAccount> = {
     return message;
   },
 };
-
-function bytesFromBase64(b64: string): Uint8Array {
-  if ((globalThis as any).Buffer) {
-    return Uint8Array.from(globalThis.Buffer.from(b64, "base64"));
-  } else {
-    const bin = globalThis.atob(b64);
-    const arr = new Uint8Array(bin.length);
-    for (let i = 0; i < bin.length; ++i) {
-      arr[i] = bin.charCodeAt(i);
-    }
-    return arr;
-  }
-}
-
-function base64FromBytes(arr: Uint8Array): string {
-  if ((globalThis as any).Buffer) {
-    return globalThis.Buffer.from(arr).toString("base64");
-  } else {
-    const bin: string[] = [];
-    arr.forEach((byte) => {
-      bin.push(globalThis.String.fromCharCode(byte));
-    });
-    return globalThis.btoa(bin.join(""));
-  }
-}
 
 type Builtin = Date | Function | Uint8Array | string | number | boolean | undefined;
 

--- a/src/client/pocket/proof/params.ts
+++ b/src/client/pocket/proof/params.ts
@@ -23,7 +23,7 @@ export interface Params {
    * is equal to or above the threshold. This is in contrast to the this requirement
    * being determined probabilistically via ProofRequestProbability.
    *
-   * TODO_MAINNET: Consider renaming this to `proof_requirement_threshold_upokt`.
+   * TODO_MAINNET_MIGRATION: Consider renaming this to `proof_requirement_threshold_upokt`.
    */
   proofRequirementThreshold:
     | Coin
@@ -32,7 +32,7 @@ export interface Params {
    * proof_missing_penalty is the number of tokens (uPOKT) which should be slashed from a supplier
    * when a proof is required (either via proof_requirement_threshold or proof_missing_penalty)
    * but is not provided.
-   * TODO_MAINNET: Consider renaming this to `proof_missing_penalty_upokt`.
+   * TODO_MAINNET_MIGRATION: Consider renaming this to `proof_missing_penalty_upokt`.
    */
   proofMissingPenalty:
     | Coin
@@ -42,7 +42,7 @@ export interface Params {
    * the supplier operator when submitting a proof.
    * This is needed to account for the cost of storing proofs onchain and prevent
    * spamming (i.e. sybil bloat attacks) the network with non-required proofs.
-   * TODO_MAINNET: Consider renaming this to `proof_submission_fee_upokt`.
+   * TODO_MAINNET_MIGRATION: Consider renaming this to `proof_submission_fee_upokt`.
    */
   proofSubmissionFee: Coin | undefined;
 }

--- a/src/client/pocket/shared/service.ts
+++ b/src/client/pocket/shared/service.ts
@@ -109,12 +109,12 @@ export function configOptionsToJSON(object: ConfigOptions): string {
 export interface Service {
   /** For example, what if we want to request a session for a certain service but with some additional configs that identify it? */
   id: string;
-  /** TODO_BETA(@bryanchriswhite): Either remove this or rename it to alias. */
+  /** TODO_POST_MAINNET: Rename service.name to service.description */
   name: string;
   /**
    * The cost of a single relay for this service in terms of compute units.
-   * Must be used alongside the global 'compute_units_to_tokens_multipler' to calculate the cost of a relay for this service.
-   * cost_per_relay_for_specific_service = compute_units_per_relay_for_specific_service * compute_units_to_tokens_multipler_global_value
+   * Must be used alongside the global 'compute_units_to_tokens_multiplier' to calculate the cost of a relay for this service.
+   * cost_per_relay_for_specific_service = compute_units_per_relay_for_specific_service * compute_units_to_tokens_multiplier_global_value
    */
   computeUnitsPerRelay: number;
   /**

--- a/src/mappings/authz/grants.ts
+++ b/src/mappings/authz/grants.ts
@@ -1,0 +1,85 @@
+import { CosmosEvent, CosmosMessage } from "@subql/types-cosmos";
+import { GenericAuthorization } from "cosmjs-types/cosmos/authz/v1beta1/authz";
+import { MsgGrant } from "cosmjs-types/cosmos/authz/v1beta1/tx";
+import { AuthzProps } from "../../types/models/Authz";
+import { getAuthzId, getBlockId, getEventId } from "../utils/ids";
+import { isEventOfFinalizedBlockKind, isEventOfMessageKind } from "../utils/primitives";
+
+function parseAttribute(attribute: unknown): string {
+  return (attribute as string).replaceAll("\"", "");
+}
+
+function _handleEventGrant(event: CosmosEvent): AuthzProps {
+  let granter: string | null = null;
+  let grantee: string | null = null;
+  let msgTypeUrl: string | null = null;
+
+  for (const attribute of event.event.attributes) {
+    if (attribute.key === "granter") {
+      granter = parseAttribute(attribute.value);
+    } else if (attribute.key === "grantee") {
+      grantee = parseAttribute(attribute.value);
+    } else if (attribute.key === "msg_type_url") {
+      msgTypeUrl = parseAttribute(attribute.value);
+    }
+  }
+
+  if (!granter) {
+    throw new Error(`[handleEventGrant] granter not found in event`);
+  }
+
+  if (!grantee) {
+    throw new Error(`[handleEventGrant] grantee not found in event`);
+  }
+
+  if (!msgTypeUrl) {
+    throw new Error(`[handleEventGrant] msgTypeUrl not found in event`);
+  }
+
+  return {
+    id: getAuthzId(
+      granter,
+      msgTypeUrl,
+      grantee,
+    ),
+    eventId: getEventId(event),
+    granterId: granter,
+    granteeId: grantee,
+    msg: msgTypeUrl,
+    type: "cosmos.authz.v1beta1.EventGrant",
+    blockId: getBlockId(event.block),
+  };
+}
+
+function _handleMsgGrant(msg: CosmosMessage<MsgGrant>): AuthzProps {
+  const {grant, grantee, granter} = msg.msg.decodedMsg;
+
+  const msgType = GenericAuthorization.decode(grant.authorization!.value).msg
+  const expiration = grant.expiration ? new Date(Number(grant.expiration.seconds) * 1000 + Math.floor(grant.expiration.nanos / 1_000_000)) : undefined
+  const event = msg.block.events.find(e => e.event.type === '' && isEventOfMessageKind(e) && e.tx.hash === msg.tx.hash)!
+
+
+  return {
+    id: getAuthzId(
+      granter,
+      msgType,
+      grantee,
+    ),
+    type: grant.authorization!.typeUrl,
+    msg: msgType,
+    blockId: getBlockId(msg.block),
+    granterId: granter,
+    granteeId: grantee,
+    eventId: getEventId(event),
+    expiration,
+  }
+}
+
+export async function handleEventGrant(events: CosmosEvent[]): Promise<void> {
+  // only handle the events that are finalized because the non-finalized events are being indexed in the /cosmos.authz.v1beta1.MsgGrant msg handler
+  await store.bulkCreate("AuthzEventGrant", events.filter(isEventOfFinalizedBlockKind).map(_handleEventGrant));
+}
+
+export async function handleMsgGrant(messages: CosmosMessage[]): Promise<void> {
+  await store.bulkCreate("Authz", messages.map(_handleMsgGrant));
+}

--- a/src/mappings/authz/grants.ts
+++ b/src/mappings/authz/grants.ts
@@ -77,7 +77,7 @@ function _handleMsgGrant(msg: CosmosMessage<MsgGrant>): AuthzProps {
 
 export async function handleEventGrant(events: CosmosEvent[]): Promise<void> {
   // only handle the events that are finalized because the non-finalized events are being indexed in the /cosmos.authz.v1beta1.MsgGrant msg handler
-  await store.bulkCreate("AuthzEventGrant", events.filter(isEventOfFinalizedBlockKind).map(_handleEventGrant));
+  await store.bulkCreate("Authz", events.filter(isEventOfFinalizedBlockKind).map(_handleEventGrant));
 }
 
 export async function handleMsgGrant(messages: CosmosMessage[]): Promise<void> {

--- a/src/mappings/handlers.ts
+++ b/src/mappings/handlers.ts
@@ -6,6 +6,7 @@ import {
   handleApplicationUnbondingEndEvent,
   handleAppMsgStake,
   handleDelegateToGatewayMsg,
+  handleMsgClaimMorseApplication,
   handleTransferApplicationBeginEvent,
   handleTransferApplicationEndEvent,
   handleTransferApplicationErrorEvent,
@@ -20,6 +21,7 @@ import {
   handleEventGatewayUnbondingBegin,
   handleEventGatewayUnbondingEnd,
 } from "./pocket/gateways";
+import { handleMsgClaimMorseAccount } from "./pocket/migration";
 import {
   handleEventApplicationOverserviced,
   handleEventApplicationReimbursementRequest,
@@ -34,6 +36,7 @@ import {
 } from "./pocket/relays";
 import { handleEventRelayMiningDifficultyUpdated, handleMsgAddService } from "./pocket/services";
 import {
+  handleMsgClaimMorseSupplier,
   handleSupplierStakeMsg,
   handleSupplierUnbondingBeginEvent,
   handleSupplierUnbondingEndEvent,
@@ -56,6 +59,7 @@ export enum ByTxStatus {
 }
 
 export const MsgHandlers: Record<string, (messages: Array<CosmosMessage>) => Promise<void>> = {
+  "/pocket.migration.MsgClaimMorseAccount": handleMsgClaimMorseAccount,
   // bank
   "/cosmos.bank.v1beta1.MsgSend": handleNativeTransfer,
   // validator
@@ -64,6 +68,7 @@ export const MsgHandlers: Record<string, (messages: Array<CosmosMessage>) => Pro
   "/cosmos.authz.v1beta1.MsgExec": handleAuthzExec,
   // application
   "/pocket.application.MsgStakeApplication": handleAppMsgStake,
+  "/pocket.migration.MsgClaimMorseApplication": handleMsgClaimMorseApplication,
   "/pocket.application.MsgDelegateToGateway": handleDelegateToGatewayMsg,
   "/pocket.application.MsgUndelegateFromGateway": handleUndelegateFromGatewayMsg,
   "/pocket.application.MsgUnstakeApplication": handleUnstakeApplicationMsg,
@@ -72,6 +77,7 @@ export const MsgHandlers: Record<string, (messages: Array<CosmosMessage>) => Pro
   "/pocket.service.MsgAddService": handleMsgAddService,
   // supplier
   "/pocket.supplier.MsgStakeSupplier": handleSupplierStakeMsg,
+  "/pocket.migration.MsgClaimMorseSupplier": handleMsgClaimMorseSupplier,
   "/pocket.supplier.MsgUnstakeSupplier": handleUnstakeSupplierMsg,
   // gateway
   "/pocket.gateway.MsgStakeGateway": handleGatewayMsgStake,

--- a/src/mappings/handlers.ts
+++ b/src/mappings/handlers.ts
@@ -1,5 +1,6 @@
 import { CosmosEvent, CosmosMessage } from "@subql/types-cosmos";
 import { handleAuthzExec } from "./authz/exec";
+import { handleEventGrant, handleMsgGrant } from "./authz/grants";
 import { handleNativeTransfer } from "./bank";
 import {
   handleApplicationUnbondingBeginEvent,
@@ -59,7 +60,12 @@ export enum ByTxStatus {
 }
 
 export const MsgHandlers: Record<string, (messages: Array<CosmosMessage>) => Promise<void>> = {
+  // authz
+  "/cosmos.authz.v1beta1.MsgGrant": handleMsgGrant,
+  // migration
   "/pocket.migration.MsgClaimMorseAccount": handleMsgClaimMorseAccount,
+  "/pocket.migration.MsgClaimMorseApplication": handleMsgClaimMorseApplication,
+  "/pocket.migration.MsgClaimMorseSupplier": handleMsgClaimMorseSupplier,
   // bank
   "/cosmos.bank.v1beta1.MsgSend": handleNativeTransfer,
   // validator
@@ -68,7 +74,6 @@ export const MsgHandlers: Record<string, (messages: Array<CosmosMessage>) => Pro
   "/cosmos.authz.v1beta1.MsgExec": handleAuthzExec,
   // application
   "/pocket.application.MsgStakeApplication": handleAppMsgStake,
-  "/pocket.migration.MsgClaimMorseApplication": handleMsgClaimMorseApplication,
   "/pocket.application.MsgDelegateToGateway": handleDelegateToGatewayMsg,
   "/pocket.application.MsgUndelegateFromGateway": handleUndelegateFromGatewayMsg,
   "/pocket.application.MsgUnstakeApplication": handleUnstakeApplicationMsg,
@@ -77,7 +82,6 @@ export const MsgHandlers: Record<string, (messages: Array<CosmosMessage>) => Pro
   "/pocket.service.MsgAddService": handleMsgAddService,
   // supplier
   "/pocket.supplier.MsgStakeSupplier": handleSupplierStakeMsg,
-  "/pocket.migration.MsgClaimMorseSupplier": handleMsgClaimMorseSupplier,
   "/pocket.supplier.MsgUnstakeSupplier": handleUnstakeSupplierMsg,
   // gateway
   "/pocket.gateway.MsgStakeGateway": handleGatewayMsgStake,
@@ -89,26 +93,7 @@ export const MsgHandlers: Record<string, (messages: Array<CosmosMessage>) => Pro
 
 export const EventHandlers: Record<string, (events: Array<CosmosEvent>) => Promise<void>> = {
   // authz
-  /*
-  todo: handle this.
-    type: cosmos.authz.v1beta1.EventGrant
-    [
-      {
-        "key": "grantee",
-        "value": "\"pokt1f0c9y7mahf2ya8tymy8g4rr75ezh3pkklu4c3e\""
-      },
-      {
-        "key": "granter",
-        "value": "\"pokt10d07y265gmmuvt4z0w9aw880jnsr700j8yv32t\""
-      },
-      {
-        "key": "msg_type_url",
-        "value": "\"/pocket.service.MsgUpdateParams\""
-      }
-    ]
-    "cosmos.authz.v1beta1.EventGrant": async () => Promise.resolve(),
-   */
-
+  "cosmos.authz.v1beta1.EventGrant": handleEventGrant,
   // Validator rewards
   // Represent the total rewards earned from block rewards and transaction fees.
   // Includes both the validator’s share and the portion allocated to delegators.

--- a/src/mappings/indexer.manager.ts
+++ b/src/mappings/indexer.manager.ts
@@ -199,6 +199,14 @@ async function indexParams(msgByType: MessageByType): Promise<void> {
   );
 }
 
+// any message or event related to Grants
+async function indexGrants(msgByType: MessageByType, eventByType: EventByType): Promise<void> {
+  await Promise.all([
+    ...handleByType("/cosmos.authz.v1beta1.MsgGrant", msgByType, MsgHandlers, ByTxStatus.Success),
+    ...handleByType("cosmos.authz.v1beta1.EventGrant", eventByType, EventHandlers, ByTxStatus.Success),
+  ]);
+}
+
 // any service msg or event
 async function indexService(msgByType: MessageByType, eventByType: EventByType): Promise<void> {
   const eventTypes = [
@@ -659,6 +667,7 @@ async function _indexingHandler(block: CosmosBlock): Promise<void> {
   await Promise.all([
     profilerWrap(indexBalances, "indexingHandler", "indexBalances")(block, msgsByType as MessageByType, eventsByType),
     profilerWrap(indexParams, "indexingHandler", "indexParams")(msgsByType as MessageByType),
+    profilerWrap(indexGrants, "indexingHandler", "indexGrants")(msgsByType as MessageByType, eventsByType),
     profilerWrap(indexService, "indexingHandler", "indexService")(msgsByType as MessageByType, eventsByType),
     profilerWrap(indexValidators, "indexingHandler", "indexValidators")(msgsByType as MessageByType, eventsByType),
     profilerWrap(indexStake, "indexingHandler", "indexStake")(msgsByType as MessageByType, eventsByType),

--- a/src/mappings/indexer.manager.ts
+++ b/src/mappings/indexer.manager.ts
@@ -226,6 +226,7 @@ async function indexApplications(msgByType: MessageByType, eventByType: EventByT
     "/pocket.application.MsgUndelegateFromGateway",
     "/pocket.application.MsgUnstakeApplication",
     "/pocket.application.MsgStakeApplication",
+    "/pocket.migration.MsgClaimMorseApplication",
     "/pocket.application.MsgTransferApplication",
   ];
   const eventTypes = [
@@ -259,6 +260,7 @@ async function indexApplications(msgByType: MessageByType, eventByType: EventByT
     "/pocket.application.MsgUndelegateFromGateway": "appAddress",
     "/pocket.application.MsgUnstakeApplication": "address",
     "/pocket.application.MsgStakeApplication": "address",
+    "/pocket.migration.MsgClaimMorseApplication": "shannonDestAddress",
     "/pocket.application.MsgTransferApplication": "sourceAddress",
     "pocket.application.EventTransferBegin": getIdOfTransferEvents,
     "pocket.application.EventTransferEnd": (attributes) => {
@@ -480,6 +482,7 @@ async function indexStakeEntity(data: Array<CosmosEvent | CosmosMessage>, getEnt
 async function indexSupplier(msgByType: MessageByType, eventByType: EventByType): Promise<void> {
   const msgTypes = [
     "/pocket.supplier.MsgUnstakeSupplier",
+    "/pocket.migration.MsgClaimMorseSupplier",
     "/pocket.supplier.MsgStakeSupplier",
   ];
   const eventTypes = [
@@ -507,6 +510,7 @@ async function indexSupplier(msgByType: MessageByType, eventByType: EventByType)
   {
     "/pocket.supplier.MsgUnstakeSupplier": "operatorAddress",
     "/pocket.supplier.MsgStakeSupplier": "operatorAddress",
+    "/pocket.migration.MsgClaimMorseSupplier": "shannonOperatorAddress",
     "pocket.supplier.EventSupplierUnbondingBegin": eventGetId,
     "pocket.supplier.EventSupplierUnbondingEnd": eventGetId,
     "pocket.tokenomics.EventSupplierSlashed": (attributes) => {
@@ -532,6 +536,16 @@ async function indexStake(msgByType: MessageByType, eventByType: EventByType): P
     indexApplications(msgByType, eventByType),
     indexGateway(msgByType, eventByType),
     indexSupplier(msgByType, eventByType),
+  ])
+}
+
+async function indexMigrationAccounts(msgByType: MessageByType): Promise<void> {
+  const msgTypes = [
+    "/pocket.migration.MsgClaimMorseAccount",
+  ];
+
+  await Promise.all([
+    ...handleByType(msgTypes, msgByType, MsgHandlers, ByTxStatus.Success),
   ])
 }
 
@@ -649,6 +663,7 @@ async function _indexingHandler(block: CosmosBlock): Promise<void> {
     profilerWrap(indexValidators, "indexingHandler", "indexValidators")(msgsByType as MessageByType, eventsByType),
     profilerWrap(indexStake, "indexingHandler", "indexStake")(msgsByType as MessageByType, eventsByType),
     profilerWrap(indexRelays, "indexingHandler", "indexRelays")(msgsByType as MessageByType, eventsByType),
+    profilerWrap(indexMigrationAccounts, "indexingHandler", "indexMigrationAccounts")(msgsByType as MessageByType),
     profilerWrap(generateReports, "indexingHandler", "generateReports")(block),
   ])
 }

--- a/src/mappings/pocket/migration.ts
+++ b/src/mappings/pocket/migration.ts
@@ -1,0 +1,158 @@
+import { toHex } from "@cosmjs/encoding";
+import type { CosmosMessage } from "@subql/types-cosmos";
+import type { Coin } from "../../client/cosmos/base/v1beta1/coin";
+import { MsgImportMorseClaimableAccounts } from "../../client/pocket/migration/tx";
+import type { MorseClaimableAccountProps } from "../../types/models/MorseClaimableAccount";
+import {
+  MsgClaimMorseAccount as MsgClaimMorseAccountEntity,
+  MsgClaimMorseAccountProps,
+} from "../../types/models/MsgClaimMorseAccount";
+import type { MsgImportMorseClaimableAccountsProps } from "../../types/models/MsgImportMorseClaimableAccounts";
+import type { CoinSDKType } from "../../types/proto-interfaces/cosmos/base/v1beta1/coin";
+import type { MsgClaimMorseAccount } from "../../types/proto-interfaces/pocket/migration/tx";
+import type { EncodedMsg } from "../types";
+import { getStoreModel } from "../utils/db";
+import { messageId } from "../utils/ids";
+import { Ed25519, pubKeyToAddress } from "../utils/pub_key";
+
+function _handleMsgClaimMorseAccount(
+  msg: CosmosMessage<MsgClaimMorseAccount>,
+): MsgClaimMorseAccountProps {
+  const msgId = messageId(msg);
+
+
+  let balanceCoin: Coin | null = null;
+
+  for (const event of msg.tx.tx.events) {
+    if (event.type === 'pocket.migration.EventMorseAccountClaimed') {
+      for (const attribute of event.attributes) {
+        if (attribute.key === 'claimed_balance') {
+          const coin: CoinSDKType = JSON.parse(attribute.value as string);
+
+          balanceCoin = {
+            denom: coin.denom,
+            amount: coin.amount,
+          }
+        }
+      }
+    }
+  }
+
+  if (!balanceCoin) {
+    throw new Error(`[handleMsgClaimMorseSupplier] balance coin not found in event`);
+  }
+
+  return MsgClaimMorseAccountEntity.create({
+    id: msgId,
+    accountId: msg.msg.decodedMsg.shannonDestAddress,
+    transactionId: msg.tx.hash,
+    blockId: BigInt(msg.block.block.header.height),
+    shannonDestAddress: msg.msg.decodedMsg.shannonDestAddress,
+    messageId: msgId,
+    morseSignature: toHex(msg.msg.decodedMsg.morseSignature),
+    morsePublicKey: toHex(msg.msg.decodedMsg.morsePublicKey),
+    morseSrcAddress: pubKeyToAddress(
+      Ed25519,
+      msg.msg.decodedMsg.morsePublicKey,
+      undefined,
+      true
+    ),
+    shannonSigningAddress: msg.msg.decodedMsg.shannonSigningAddress,
+    balanceAmount: BigInt(balanceCoin.amount),
+    balanceDenom: balanceCoin.denom,
+  })
+}
+
+export async function updateMorseClaimableAccounts(
+  items: Array<{
+    publicKey: Uint8Array
+    destinationAddress: string
+  }>,
+): Promise<void> {
+  const MorseClaimableAccountModel = getStoreModel("MorseClaimableAccount");
+  const blockHeight = store.context.getHistoricalUnit();
+
+  await Promise.all(
+    items.map(({ destinationAddress, publicKey }) => MorseClaimableAccountModel.model.update(
+      // mark as claimed
+      {
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        claimed_at_height: blockHeight,
+        claimed: true,
+        shannon_dest_address: destinationAddress,
+      },
+      {
+        hooks: false,
+        where: {
+          id: pubKeyToAddress(
+            Ed25519,
+            publicKey,
+            undefined,
+            true
+          )
+        },
+        transaction: store.context.transaction,
+      },
+    ))
+  )
+}
+
+export async function handleMsgClaimMorseAccount(
+  messages: Array<CosmosMessage<MsgClaimMorseAccount>>,
+): Promise<void> {
+  await Promise.all([
+    store.bulkCreate("MsgClaimMorseAccount", messages.map(_handleMsgClaimMorseAccount)),
+    updateMorseClaimableAccounts(
+      messages.map((msg) => ({
+        publicKey: msg.msg.decodedMsg.morsePublicKey,
+        destinationAddress: msg.msg.decodedMsg.shannonDestAddress,
+      }))
+    )
+  ]);
+}
+
+interface HandleMsgImportMorseClaimableAccountsProps {
+  encodedMsg: EncodedMsg,
+  blockId: bigint
+  transactionId: string
+  messageId: string
+}
+
+export function handleMsgImportMorseClaimableAccounts({
+  blockId,
+  encodedMsg,
+  messageId,
+  transactionId,
+}: HandleMsgImportMorseClaimableAccountsProps): {
+  decodedMsg: object
+  msgImportMorseClaimableAccounts: MsgImportMorseClaimableAccountsProps
+  morseClaimableAccounts: Array<MorseClaimableAccountProps>
+} {
+  const decodedMsg = MsgImportMorseClaimableAccounts.decode(
+    new Uint8Array(Object.values(encodedMsg.value))
+  );
+
+  return {
+    decodedMsg,
+    msgImportMorseClaimableAccounts: {
+      id: messageId,
+      blockId: blockId,
+      transactionId,
+      messageId,
+      morseAccountStateHash: toHex(decodedMsg.morseAccountStateHash),
+      authorityId: decodedMsg.authority
+    },
+    morseClaimableAccounts: decodedMsg.morseAccountState!.accounts.map((account) => ({
+      id: account.morseSrcAddress.toLowerCase(),
+      msgImportMorseClaimableAccountsId: messageId,
+      applicationStakeAmount: BigInt(account.applicationStake?.amount || 0),
+      applicationStakeDenom: account.applicationStake?.denom || "",
+      supplierStakeAmount: BigInt(account.applicationStake?.amount || 0),
+      supplierStakeDenom: account.supplierStake?.denom || "",
+      claimed: false,
+      unstakedBalanceAmount: BigInt(account.unstakedBalance?.amount || 0),
+      unstakedBalanceDenom: account.unstakedBalance?.denom || "",
+    }))
+  }
+}

--- a/src/mappings/primitives/genesis.ts
+++ b/src/mappings/primitives/genesis.ts
@@ -64,6 +64,7 @@ import {
 import { optimizedBulkCreate } from "../utils/db";
 import {
   getAppDelegatedToGatewayId,
+  getAuthzId,
   getBalanceId,
   getBlockId,
   getGenesisFakeTxHash,
@@ -254,7 +255,11 @@ async function _handleAuthz(genesis: Genesis, block: CosmosBlock): Promise<void>
     const auth = authorization.authorization as unknown as Record<string, string>;
 
     authz.push({
-      id: `${authorization.granter}:${auth.msg.replace("/", "") as string}-${authorization.grantee}`,
+      id: getAuthzId(
+        authorization.granter,
+        auth.msg,
+        authorization.grantee,
+      ),
       granterId: authorization.granter,
       granteeId: authorization.grantee,
       expiration: authorization.expiration ? new Date(authorization.expiration) : undefined,

--- a/src/mappings/utils/ids.ts
+++ b/src/mappings/utils/ids.ts
@@ -99,6 +99,14 @@ export function getRelayId({
   return `${supplierId}-${applicationId}-${serviceId}-${sessionId}`;
 }
 
+export function getAuthzId(
+  granter: string,
+  msg: string,
+  grantee: string,
+): string {
+  return `${granter}:${msg.replace("/", "") as string}-${grantee}`;
+}
+
 // always the same to ensure we get consistent results
 const namespace = "6ba7b810-9dad-11d1-80b4-00c04fd430c8";
 

--- a/src/mappings/utils/pub_key.ts
+++ b/src/mappings/utils/pub_key.ts
@@ -70,6 +70,7 @@ export function base64PubKeyToAddress(type: string, base64PubKey: string, prefix
   return pubKeyToRawAddress(type, fromBase64(base64PubKey), prefix);
 }
 
-export function pubKeyToAddress(type: string, pubKey: Uint8Array, prefix?: string): string {
-  return pubKeyToRawAddress(type, pubKey, prefix);
+export function pubKeyToAddress(type: string, pubKey: Uint8Array, prefix?: string, toLowerCase?: boolean): string {
+  const address = pubKeyToRawAddress(type, pubKey, prefix)
+  return toLowerCase ? address.toLowerCase() : address
 }


### PR DESCRIPTION
## Summary

* Added handlers for `MsgClaimMorseApplication`, `MsgClaimMorseAccount`, `MsgClaimMorseSupplier` and `MsgImportMorseClaimableAccounts`
* Updated proto and client files because the migration one were outdated
* Added handlers for `/cosmos.authz.v1beta1.MsgGrant` and `cosmos.authz.v1beta1.EventGrant` events

## Issue

* We were not handling the migration messages and events
* Proto and client files were outdated

## Type of change

Select one or more:

- [x] New feature, functionality or library
- [ ] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## Sanity Checklist

- [x] I have tested my changes using the available tooling
- [x] I have commented my code
- [x] I have performed a self-review of my own code; both comments & source code
- [ ] I create and reference any new tickets, if applicable
- [ ] I have left TODOs throughout the codebase, if applicable
