### PR TITLE
Refactored `indexStakeEntity` to only process successful data

### DIFF
--- a/src/mappings/indexer.manager.ts
+++ b/src/mappings/indexer.manager.ts
@@ -378,7 +378,26 @@ This function is used to call handlers in order to avoid updating the same entit
     for messages it is the path of the decodedMsg to get the entity id
     for events it is a function that receives the attributes and returns the entity id
 */
-async function indexStakeEntity(data: Array<CosmosEvent | CosmosMessage>, getEntityIdArg: RecordGetId) {
+async function indexStakeEntity(allData: Array<CosmosEvent | CosmosMessage>, getEntityIdArg: RecordGetId) {
+  const allEvents: Array<CosmosEvent> = [], allMsgs: Array<CosmosMessage> = [];
+
+  for (const datum of allData) {
+    if ('event' in datum) {
+      allEvents.push(datum)
+    } else {
+      allMsgs.push(datum)
+    }
+  }
+
+  const {success: successfulEvents} = filterEventsByTxStatus(allEvents)
+
+  const {success: successfulMsgs} = filterMsgByTxStatus(allMsgs)
+
+  const data = [
+    ...successfulEvents,
+    ...successfulMsgs,
+  ]
+
   // this is to handle events where more than one stake entity is updated
   // like in _handleTransferApplicationEndEvent handler
   const entitiesUpdatedAtSameDatum: Array<Array<string>> = [];

--- a/src/mappings/pocket/migration.ts
+++ b/src/mappings/pocket/migration.ts
@@ -65,7 +65,8 @@ function _handleMsgClaimMorseAccount(
 
 export async function updateMorseClaimableAccounts(
   items: Array<{
-    publicKey: Uint8Array
+    publicKey?: Uint8Array
+    morseAddress?: string
     destinationAddress: string
   }>,
 ): Promise<void> {
@@ -73,7 +74,7 @@ export async function updateMorseClaimableAccounts(
   const blockHeight = store.context.getHistoricalUnit();
 
   await Promise.all(
-    items.map(({ destinationAddress, publicKey }) => MorseClaimableAccountModel.model.update(
+    items.map(({ destinationAddress, morseAddress, publicKey }) => MorseClaimableAccountModel.model.update(
       // mark as claimed
       {
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment
@@ -85,9 +86,9 @@ export async function updateMorseClaimableAccounts(
       {
         hooks: false,
         where: {
-          id: pubKeyToAddress(
+          id: morseAddress ? morseAddress : pubKeyToAddress(
             Ed25519,
-            publicKey,
+            publicKey!,
             undefined,
             true
           )

--- a/src/mappings/pocket/suppliers.ts
+++ b/src/mappings/pocket/suppliers.ts
@@ -484,7 +484,7 @@ export async function handleMsgClaimMorseSupplier(
     ...messages.map(_handleMsgClaimMorseSupplier),
     updateMorseClaimableAccounts(
       messages.map((msg) => ({
-        publicKey: msg.msg.decodedMsg.morsePublicKey,
+        morseAddress: msg.msg.decodedMsg.morseNodeAddress,
         destinationAddress: msg.msg.decodedMsg.shannonOperatorAddress,
       }))
     )


### PR DESCRIPTION
## Summary

* Refactored `indexStakeEntity` to only process successful data
* Updated `updateMorseClaimableAccounts` to handle optional `publicKey` and new `morseAddress` field.

## Issue

We were unintentionally handling data from failed transactions in  `indexStakeEntity` causing errors. Also the update of the morse claimable supplier accounts were not working.

## Type of change

Select one or more:

- [ ] New feature, functionality or library
- [X] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## Sanity Checklist

- [X] I have tested my changes using the available tooling
- [X] I have commented my code
- [X] I have performed a self-review of my own code; both comments & source code
- [ ] I create and reference any new tickets, if applicable
- [ ] I have left TODOs throughout the codebase, if applicable
