### PR TITLE
Add handling and utilities for multisignature transactions

### DIFF
--- a/src/mappings/primitives/transactions.ts
+++ b/src/mappings/primitives/transactions.ts
@@ -4,6 +4,7 @@ import {
   isNil,
 } from "lodash";
 import { TransactionProps } from "../../types/models/Transaction";
+import { SignerInfo } from "../../types/proto-interfaces/cosmos/tx/v1beta1/tx";
 import {
   PREFIX,
   VALIDATOR_PREFIX,
@@ -11,55 +12,57 @@ import {
 import { optimizedBulkCreate } from "../utils/db";
 import { getBlockId } from "../utils/ids";
 import {
+  getMultisigInfo,
+  isMulti,
+} from "../utils/multisig";
+import {
   getTxStatus,
   isMsgValidatorRelated,
 } from "../utils/primitives";
 import {
-  MultisigLegacyAminoPubKey,
   pubKeyToAddress,
   Secp256k1,
 } from "../utils/pub_key";
-import { LegacyAminoPubKey } from "../../types/proto-interfaces/cosmos/crypto/multisig/keys";
 
 function _handleTransaction(tx: CosmosTransaction): TransactionProps {
   let signerAddress;
-  if (isEmpty(tx.decodedTx.authInfo.signerInfos) || isNil(tx.decodedTx.authInfo.signerInfos[0]?.publicKey)) {
-    throw new Error(`[handleTransaction] (block ${tx.block.block.header.height}): hash=${tx.hash} missing signerInfos public key`);
-  } else {
-    const prefix = isMsgValidatorRelated(tx.decodedTx.body.messages[0].typeUrl) ? VALIDATOR_PREFIX : PREFIX;
-    // if the first message is a MsgCreateValidator, we assume the signer is the account related to it,
-    // that is hashed with a different prefix.
-    const signerType = tx.decodedTx.authInfo.signerInfos[0]?.publicKey.typeUrl;
 
-    if (signerType === MultisigLegacyAminoPubKey) {
-      try {
-        // TODO: Add support for multisign
-        // Beta network:
-        // MultiSign TX 8FBC06F36312F48E3ECABDDC145322BF24C322BAB37F9A3D7B9AA2430C16CC16
-        // Block: 39712
-        // This results in error since signersInfo.publicKeys is not an array, maybe public_keys or current cosmosjs
-        // does not handle this well?
-        const signersInfo = tx.decodedTx.authInfo.signerInfos[0] as unknown as LegacyAminoPubKey;
-        const signers = (signersInfo.publicKeys as unknown as [Uint8Array]).map((value: Uint8Array) => pubKeyToAddress(
-          signerType,
-          value,
-          prefix,
-        ));
-        console.log(`MultisigLegacyAminoPubKey: ${signers.join(", ")}`);
-        signerAddress = signers[0]; // TODO: we need to handle this properly as multisign
-      } catch (e) {
-        signerAddress = `Unsupported pubkey type: ${signerType}`;
-        console.error(e);
-      }
-    } else if (signerType === Secp256k1) {
-      signerAddress = pubKeyToAddress(
-        signerType,
-        tx.decodedTx.authInfo.signerInfos[0]?.publicKey.value,
-        prefix,
-      );
-    } else {
-      signerAddress = `Unsupported pubkey type: ${signerType}`;
-    }
+  if (isEmpty(tx.decodedTx.authInfo.signerInfos) || isNil(tx.decodedTx.authInfo.signerInfos[0].publicKey)) {
+    throw new Error(`[handleTransaction] (block ${tx.block.block.header.height}): hash=${tx.hash} missing signerInfos public key`);
+  }
+
+  const prefix = isMsgValidatorRelated(tx.decodedTx.body.messages[0].typeUrl) ? VALIDATOR_PREFIX : PREFIX;
+
+  const signerInfo = (tx.decodedTx.authInfo.signerInfos as SignerInfo[])[0];
+
+  if (!signerInfo.publicKey) {
+    throw new Error(`[handleTransaction] (block ${tx.block.block.header.height}): hash=${tx.hash} missing signerInfos public key`);
+  }
+
+  const signerType = signerInfo.publicKey.typeUrl;
+
+  if (isMulti(signerInfo)) {
+    const {
+      allSignerAddresses,
+      fromAddress,
+      signedSignerAddresses,
+    } = getMultisigInfo(signerInfo);
+
+    console.log("[handleTransaction] MultiSig -> From:", fromAddress);
+    console.log("[handleTransaction] MultiSig -> All: ", allSignerAddresses);
+    console.log("[handleTransaction] MultiSig -> Signed:", signedSignerAddresses);
+
+    // TODO: Add another properties to transaction to display that this is a multisig one
+    // TODO: We should probably "create" this account otherwise maybe will not exists?
+    signerAddress = fromAddress;
+  } else if (signerType === Secp256k1) {
+    signerAddress = pubKeyToAddress(
+      signerType,
+      tx.decodedTx.authInfo.signerInfos[0]?.publicKey.value,
+      prefix,
+    );
+  } else {
+    signerAddress = `Unsupported Signer: ${signerType}`;
   }
 
   const feeAmount = !isNil(tx.decodedTx.authInfo.fee) ? tx.decodedTx.authInfo.fee.amount : [];

--- a/src/mappings/utils/multisig.ts
+++ b/src/mappings/utils/multisig.ts
@@ -1,0 +1,145 @@
+import {
+  createMultisigThresholdPubkey,
+  encodeSecp256k1Pubkey,
+  pubkeyToAddress,
+  SinglePubkey,
+} from "@cosmjs/amino";
+import {
+  fromBase64,
+  toBase64,
+} from "@cosmjs/encoding";
+import { decodePubkey } from "@cosmjs/proto-signing";
+import { SignerInfo } from "../../types/proto-interfaces/cosmos/tx/v1beta1/tx";
+import { MultisigLegacyAminoPubKey } from "./pub_key";
+
+export interface MultisigInfo {
+  fromAddress: string;
+  allSignerAddresses: string[];
+  signedSignerAddresses: string[];
+}
+
+/**
+ * Decode a base64-encoded bitarray and return indices of public keys that signed.
+ */
+function decodeBitArray(elemsBase64: string, extraBitsStored: number): number[] {
+  const bitArray = fromBase64(elemsBase64);
+  console.log("Decoded bitArray:", [...bitArray]);
+  console.log("extraBitsStored:", extraBitsStored);
+
+  const signerIndices: number[] = [];
+
+  for (let i = 0; i < extraBitsStored; i++) {
+    const byteIndex = Math.floor(i / 8);
+    const bitIndex = i % 8;
+    const byte = bitArray[byteIndex];
+
+    // Cosmos uses MSB first: bit 0 is the highest bit in the byte
+    const bit = (byte >> (7 - bitIndex)) & 1;
+
+    console.log(`bit ${i}: byte[${byteIndex}] = ${byte.toString(2).padStart(8, "0")} → MSB bit ${7 - bitIndex} = ${bit === 1}`);
+
+    if (bit === 1) {
+      signerIndices.push(i);
+    }
+  }
+
+  console.log("Decoded signer indices:", signerIndices);
+  return signerIndices;
+}
+
+export function getMultiSignPubKeyAddress(pubkeysBase64: string[], threshold: number, prefix: string): string {
+  // Step 1: Encode each base64 pubkey as Amino SinglePubkey
+  const pubkeyObjs: SinglePubkey[] = pubkeysBase64.map((b64) =>
+    encodeSecp256k1Pubkey(fromBase64(b64)),
+  );
+
+  // Step 2: Build a multisig pubkey and derive fromAddress
+  const multisigPubkey = createMultisigThresholdPubkey(pubkeyObjs, threshold);
+  return pubkeyToAddress(multisigPubkey, prefix);
+}
+
+/**
+ * Parse all multisig signer info including fromAddress, all signers, and who actually signed.
+ */
+export function parseMultisigSignerInfo({
+                                          bitarrayElems,
+                                          extraBitsStored,
+                                          prefix,
+                                          pubkeysBase64,
+                                          threshold,
+                                        }: {
+  pubkeysBase64: string[];
+  threshold: number;
+  bitarrayElems: string;
+  extraBitsStored: number;
+  prefix: string;
+}): MultisigInfo {
+  // Step 1: Encode each base64 pubkey as Amino SinglePubkey
+  const pubkeyObjs: SinglePubkey[] = pubkeysBase64.map((b64) =>
+    encodeSecp256k1Pubkey(fromBase64(b64)),
+  );
+
+  // Step 2: Build a multisig pubkey and derive fromAddress
+  const fromAddress = getMultiSignPubKeyAddress(pubkeysBase64, threshold, prefix);
+
+  // Step 3: All signer addresses
+  const allSignerAddresses = pubkeyObjs.map((pk) => pubkeyToAddress(pk, prefix));
+
+  // Step 4: Decode the bitarray to find actual signers
+  const signerIndices = decodeBitArray(bitarrayElems, extraBitsStored);
+  const signedSignerAddresses = signerIndices.map((i) => allSignerAddresses[i]);
+
+  return {
+    fromAddress,
+    allSignerAddresses,
+    signedSignerAddresses,
+  };
+}
+
+export function extractThresholdAndPubkeysFromMultisig(pubkeyBytes: Uint8Array): {
+  threshold: number;
+  pubkeysBase64: string[];
+} {
+  const decoded = decodePubkey({
+    typeUrl: "/cosmos.crypto.multisig.LegacyAminoPubKey",
+    value: pubkeyBytes,
+  });
+
+  if (!decoded || decoded.type !== "tendermint/PubKeyMultisigThreshold") {
+    throw new Error("Not a valid multisig pubkey");
+  }
+
+  const { pubkeys, threshold } = decoded.value;
+  const pubkeysBase64 = pubkeys.map((pk: { value: any; }) => pk.value); // already base64
+
+  return {
+    threshold: Number(threshold),
+    pubkeysBase64,
+  };
+}
+
+export function getMultisigInfo(signerInfo: SignerInfo): MultisigInfo {
+  if (!signerInfo || !isMulti(signerInfo)) {
+    throw new Error("[getMultisigInfo] signerInfo is not a multisig");
+  }
+  if (!signerInfo.publicKey) {
+    throw new Error("[getMultisigInfo] missing signerInfos public key");
+  }
+  const { pubkeysBase64, threshold } = extractThresholdAndPubkeysFromMultisig(signerInfo.publicKey.value);
+
+  return parseMultisigSignerInfo({
+    pubkeysBase64,
+    threshold,
+    bitarrayElems: toBase64(signerInfo.modeInfo?.multi?.bitarray?.elems as Uint8Array<ArrayBufferLike>),
+    extraBitsStored: signerInfo.modeInfo?.multi?.bitarray?.extraBitsStored as number,
+    prefix: "pokt",
+  });
+}
+
+export function isMulti(signerInfo: SignerInfo): boolean {
+  if (!signerInfo.publicKey) {
+    throw new Error(`missing signerInfos public key`);
+  }
+
+  return signerInfo.publicKey.typeUrl === MultisigLegacyAminoPubKey;
+}

--- a/src/mappings/utils/pub_key.ts
+++ b/src/mappings/utils/pub_key.ts
@@ -14,6 +14,7 @@ import {
 
 export const Secp256k1 = "/cosmos.crypto.secp256k1.PubKey";
 export const Ed25519 = "/cosmos.crypto.ed25519.PubKey";
+export const MultisigLegacyAminoPubKey = "/cosmos.crypto.multisig.LegacyAminoPubKey";
 
 function rawEd25519PubKeyToRawAddress(pubKey: Uint8Array): Uint8Array {
   let pk = pubKey;


### PR DESCRIPTION
## Summary

Add robust handling and utilities for multisignature transactions

- Introduced new utilities in `multisig.ts` to handle multisignature decoding, parsing, and validation.
- Enhanced transaction processing flows to support multisignature accounts and proper address derivation.
- Updated `transactions.ts` and `validator.ts` to integrate multisign-specific functionality.
- Improved error handling and added support for `Secp256k1` and `LegacyAminoPubKey` multisig types.
- Added placeholders for future multisign account support and related transaction properties.

TODO: Right now it will just set the signer as the from address, so we need to extend this to include multisig information that later is used on explorer to explain it is a Multisig tx.

## Type of change

Select one or more:

- [x] New feature, functionality or library
- [x] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## Sanity Checklist

- [x] I have tested my changes using the available tooling
- [x] I have commented my code
- [x] I have performed a self-review of my own code; both comments & source code
- [ ] I create and reference any new tickets, if applicable
- [x] I have left TODOs throughout the codebase, if applicable
