### PR TITLE
Add `getOverservicedsByDelegatorAddressesAndTimesFn` and fix typo

### DIFF
--- a/src/mappings/dbFunctions/claimProofs.ts
+++ b/src/mappings/dbFunctions/claimProofs.ts
@@ -30,7 +30,7 @@ AS $$
       SUM(mcc.num_relays) AS claim_relays,
       SUM(mcc.num_estimated_relays) AS claim_estimated_relays,
       SUM(mcc.num_claimed_computed_units) AS claim_computed_units,
-      SUM(mcc.num_estimated_computed_units) AS claim_estimated_units,
+      SUM(mcc.num_estimated_computed_units) AS claim_estimated_computed_units,
       SUM(mcc.claimed_amount) AS claim_upokt
     FROM ${dbSchema}.msg_create_claims mcc
     INNER JOIN ${dbSchema}.blocks b ON b.id = mcc.block_id

--- a/src/mappings/dbFunctions/index.ts
+++ b/src/mappings/dbFunctions/index.ts
@@ -6,6 +6,7 @@ import { getDataByDelegatorAddressesAndBlocksFn } from "./dataByDelegatorAddress
 import {
   getDataByDelegatorAddressesAndTimesFn,
 } from "./dataByDelegatorAddressesAndTimes";
+import { getOverservicedsByDelegatorAddressesAndTimesFn } from "./overserviced";
 import { getRelaysByServicePerPointJsonFn } from "./relaysByServicePerPoint";
 import { createNeededExtensions, updateBlockReportsFn, updateBlockReportsRangeFn } from "./reports";
 import {
@@ -125,6 +126,7 @@ export async function createDbFunctions(): Promise<void> {
     getMintBreakdownBetweenDatesFn,
     getSupplyCompositionBetweenDatesFn,
     getTotalSupplyBetweenDatesFn,
+    getOverservicedsByDelegatorAddressesAndTimesFn,
   )
 
   logger.info(`[createDbFunctions] db functions were saved successfully to schema=${schema}.`)

--- a/src/mappings/dbFunctions/overserviced.ts
+++ b/src/mappings/dbFunctions/overserviced.ts
@@ -1,0 +1,45 @@
+// Used to get the proof, claim and slash data between block timestamps and for the list of delegator addresses
+export function getOverservicedsByDelegatorAddressesAndTimesFn (dbSchema: string): string {
+  return `CREATE OR REPLACE FUNCTION ${dbSchema}.get_overserviced_by_addresses_and_time(
+  addresses TEXT[],
+  start_ts TIMESTAMP,
+  end_ts TIMESTAMP,
+  trunc_interval TEXT
+)
+RETURNS jsonb
+LANGUAGE sql
+STABLE
+AS $$
+WITH matched_suppliers AS (
+  	SELECT
+      distinct ssc.supplier_id
+    FROM ${dbSchema}.supplier_service_configs ssc
+    INNER JOIN ${dbSchema}.suppliers s ON s.id = ssc.supplier_id
+    CROSS JOIN jsonb_array_elements(ssc.rev_share) AS elem
+    WHERE elem->>'address' = ANY (addresses)
+      AND upper_inf(ssc._block_range)
+      AND s.stake_status = 'Staked'
+      AND upper_inf(s._block_range)
+  ),
+  overserviced as (
+	SELECT
+    date_trunc(trunc_interval, b.timestamp) AS date_truncated, 
+		SUM(o.expected_burn) expected_burn,
+		SUM(o.effective_burn) effective_burn
+	FROM ${dbSchema}.event_application_overserviceds o
+	INNER JOIN ${dbSchema}.blocks b ON b.id = o.block_id
+	WHERE o.supplier_id IN (SELECT supplier_id FROM matched_suppliers) AND b.timestamp BETWEEN start_ts AND end_ts
+	GROUP BY date_truncated
+  ORDER BY date_truncated
+  )
+
+  SELECT jsonb_agg(
+    jsonb_build_object(
+      'date_truncated', date_truncated,
+      'expected_burn', COALESCE(expected_burn, 0),
+      'effective_burn', COALESCE(effective_burn, 0)
+    )
+  ) FROM overserviced
+$$;
+`
+}


### PR DESCRIPTION
## Summary

- Introduced a new database function to fetch overserviced data by delegator addresses and time.
- Corrected a typo in the key mapping for `numEstimatedComputedUnits`.

## Issue

- There was a typo in the function `getClaimProofsDataByDelegatorsAndTimeFn`.
- Missing db function to expose aggregation of EventApplicationOverserviced events by delegator addresses of suppliers.

## Type of change

Select one or more:

- [x] New feature, functionality or library
- [x] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## Sanity Checklist

- [x] I have tested my changes using the available tooling
- [x] I have commented my code
- [x] I have performed a self-review of my own code; both comments & source code
- [ ] I create and reference any new tickets, if applicable
- [ ] I have left TODOs throughout the codebase, if applicable
