### PR TITLE
Add handle MsgAdminRecoverMorseAccount

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -1219,6 +1219,7 @@ type MsgRecoverMorseAccount @entity {
   morseSrcAddress: String!
   recoveredBalanceAmount: BigInt!
   recoveredBalanceDenom: String!
+  isAdmin: Boolean
 
   block: Block!
   transaction: Transaction!

--- a/src/mappings/authz/exec.ts
+++ b/src/mappings/authz/exec.ts
@@ -86,12 +86,16 @@ function _handleAuthzExec(msg: CosmosMessage<AuthzExecMsg>): HandleAuthzExecResu
       decodedMsg = response.decodedMsg;
       result.morseClaimableAccount.push(...response.morseClaimableAccounts);
       result.msgImportMorseClaimableAccounts.push(response.msgImportMorseClaimableAccounts);
-    } else if (encodedMsg.typeUrl === "/pocket.migration.MsgRecoverMorseAccount") {
+    } else if (
+      encodedMsg.typeUrl === "/pocket.migration.MsgRecoverMorseAccount" ||
+      encodedMsg.typeUrl === "/pocket.migration.MsgAdminRecoverMorseAccount"
+    ) {
       const response = handleMsgRecoverMorseAccount({
         encodedMsg,
         blockId,
         tx: msg.tx,
         messageId: authzExecId,
+        isAdmin: encodedMsg.typeUrl === "/pocket.migration.MsgAdminRecoverMorseAccount"
       })
 
       decodedMsg = response.decodedMsg;

--- a/src/mappings/pocket/migration.ts
+++ b/src/mappings/pocket/migration.ts
@@ -1,7 +1,11 @@
 import { toHex } from "@cosmjs/encoding";
 import type { CosmosMessage, CosmosTransaction } from "@subql/types-cosmos";
 import type { Coin } from "../../client/cosmos/base/v1beta1/coin";
-import { MsgImportMorseClaimableAccounts, MsgRecoverMorseAccount } from "../../client/pocket/migration/tx";
+import {
+  MsgAdminRecoverMorseAccount,
+  MsgImportMorseClaimableAccounts,
+  MsgRecoverMorseAccount,
+} from "../../client/pocket/migration/tx";
 import type { MorseClaimableAccountProps } from "../../types/models/MorseClaimableAccount";
 import {
   MsgClaimMorseAccount as MsgClaimMorseAccountEntity,
@@ -70,25 +74,30 @@ interface HandleMsgRecoverMorseAccount {
   tx: CosmosTransaction
   blockId: bigint
   messageId: string
+  isAdmin: boolean
 }
 
 export function handleMsgRecoverMorseAccount({
   blockId,
   encodedMsg,
+  isAdmin,
   messageId,
   tx,
 }: HandleMsgRecoverMorseAccount): {
   decodedMsg: object
   msgRecoverMorseAccount: MsgRecoverMorseAccountProps
 } {
-  const decodedMsg = MsgRecoverMorseAccount.decode(
+  const Proto = isAdmin ? MsgAdminRecoverMorseAccount : MsgRecoverMorseAccount;
+  const decodedMsg = Proto.decode(
     new Uint8Array(Object.values(encodedMsg.value))
   )
+
+  const eventTypeTarget = isAdmin ? 'pocket.migration.EventMorseAccountRecoveredAdmin' : 'pocket.migration.EventMorseAccountRecovered';
 
   let recoveredBalance: Coin | null = null;
 
   for (const event of tx.tx.events) {
-    if (event.type === 'pocket.migration.EventMorseAccountRecovered') {
+    if (event.type === eventTypeTarget) {
       let coin: CoinSDKType | null = null, morseAddress: string | null = null, shannonAddress: string | null = null;
 
       for (const attribute of event.attributes) {
@@ -135,6 +144,7 @@ export function handleMsgRecoverMorseAccount({
       blockId: blockId,
       transactionId: tx.hash,
       messageId: messageId,
+      isAdmin,
     }
   }
 }


### PR DESCRIPTION
## Summary

- Added `isAdmin` field to `schema.graphql`.
- Enhanced `handleMsgRecoverMorseAccount` to distinguish between regular and admin Morse account recoveries.

## Issue

Handle missing for message `MsgAdminRecoverMorseAccount`.

## Type of change

Select one or more:

- [x] New feature, functionality or library
- [ ] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## Sanity Checklist

- [x] I have tested my changes using the available tooling
- [x] I have commented my code
- [x] I have performed a self-review of my own code; both comments & source code
- [ ] I create and reference any new tickets, if applicable
- [ ] I have left TODOs throughout the codebase, if applicable
