### PR TITLE
Feature/0.1.33 events

### DIFF
--- a/project.ts
+++ b/project.ts
@@ -369,6 +369,8 @@ const project: CosmosProject = {
             "EventSupplierSlashed",
             "EventApplicationOverserviced",
             "EventApplicationReimbursementRequest",
+            "EventSettlementBatch",
+            "RewardDistributionDetail",
           ],
         },
       ],

--- a/proto/pocket/tokenomics/event.proto
+++ b/proto/pocket/tokenomics/event.proto
@@ -77,7 +77,7 @@ message EventClaimExpired {
 // EventClaimSettled is emitted during settlement whenever a claim is successfully settled.
 // It may or may not require a proof depending on various on-chain parameters and other factors.
 message EventClaimSettled {
-    // Next index: 15
+    // Next index: 24
 
     // pocket.proof.Claim claim = 1 [(gogoproto.jsontag) = "claim"];
     // cosmos.base.v1beta1.Coin claimed_upokt = 6 [(gogoproto.jsontag) = "claimed_upokt"];
@@ -134,14 +134,57 @@ message EventClaimSettled {
     string supplier_operator_address = 13 [(cosmos_proto.scalar) = "cosmos.AddressString"];
 
     // A map of addresses to token amounts corresponding to the distribution of the reward tokens.
+    // Deprecated: Use reward_distribution_detailed which preserves OpReason per entry.
     map<string, string> reward_distribution = 14 [(gogoproto.nullable) = false, (gogoproto.jsontag) = "mint_distribution"];
+
+    // Detailed per-reason reward breakdown. Unlike reward_distribution (field 14)
+    // which merges all reasons per address, this preserves the OpReason for each entry.
+    repeated RewardDistributionDetail reward_distribution_detailed = 15 [(gogoproto.nullable) = false, (gogoproto.jsontag) = "reward_distribution_detailed"];
+
+    // The actual settlement amount after overservicing cap, before mint_ratio.
+    // Indexers can compute: overservicing_loss = claimed_upokt - settled_upokt
+    string settled_upokt = 16 [(gogoproto.jsontag) = "settled_upokt"];
+
+    // The mint_ratio applied during settlement (from tokenomics params).
+    // Indexers can compute: deflation_loss = settled_upokt * (1 - mint_ratio)
+    string mint_ratio = 17 [(gogoproto.jsontag) = "mint_ratio"];
+
+    // The unique session ID hash for this claim's session.
+    // Enables direct joins without needing composite keys (app + service + session_end).
+    string session_id = 18 [(gogoproto.jsontag) = "session_id"];
+
+    // The owner address of the supplier who submitted the claim.
+    // Useful when owner != operator (delegated staking) for attributing rewards.
+    string supplier_owner_address = 19 [(cosmos_proto.scalar) = "cosmos.AddressString", (gogoproto.jsontag) = "supplier_owner_address"];
+
+    // The probabilistic estimation of the total number of relays served in this session.
+    // Derived from the relay mining difficulty: num_estimated_relays = num_relays * difficulty_multiplier.
+    // Unlike num_relays (which is only the count of leaves in the session tree that matched
+    // the relay mining difficulty), this reflects the actual estimated workload.
+    uint64 num_estimated_relays = 20 [(gogoproto.jsontag) = "num_estimated_relays"];
+
+    // The actual amount of uPOKT minted for this claim via the Relay Burn Equals Mint TLM.
+    // minted_upokt = settled_upokt * mint_ratio (truncated to integer).
+    // This is the real economic value created by this claim after both overservicing and deflation.
+    // Relationship: claimed_upokt >= settled_upokt >= minted_upokt
+    string minted_upokt = 21 [(gogoproto.jsontag) = "minted_upokt"];
+
+    // The amount of uPOKT lost to overservicing for this claim.
+    // overservicing_loss_upokt = claimed_upokt - settled_upokt.
+    // Zero when the supplier's claim fits within the application's per-supplier budget.
+    string overservicing_loss_upokt = 22 [(gogoproto.jsontag) = "overservicing_loss_upokt"];
+
+    // The amount of uPOKT permanently removed from circulation (deflation) for this claim.
+    // deflation_loss_upokt = settled_upokt - minted_upokt = settled_upokt * (1 - mint_ratio).
+    // Zero when mint_ratio = 1 (no deflation).
+    string deflation_loss_upokt = 23 [(gogoproto.jsontag) = "deflation_loss_upokt"];
 }
 
 // EventApplicationOverserviced is emitted when an Application's stake cannot cover the Supplier's claim.
 // This means the following will ALWAYS be strictly true:  effective_burn < expected_burn
 // - Number of tokens burnt from app stake < Number of tokens burnt from supplier stake
 message EventApplicationOverserviced {
-    // Next index: 7
+    // Next index: 10
 
     // cosmos.base.v1beta1.Coin expected_burn = 3;
     // cosmos.base.v1beta1.Coin effective_burn = 4;
@@ -160,6 +203,19 @@ message EventApplicationOverserviced {
     // Actual number of tokens burnt from the application's stake.
     // A function of the amount that could be covered (less than) relative to the amount of work claimed to be done.
     string effective_burn  = 6;
+
+    // The Service ID for the session where overservicing occurred.
+    // Enables unambiguous joins with EventClaimSettled.
+    string service_id = 7;
+
+    // The session end block height where overservicing occurred.
+    // Together with service_id, application_addr, and supplier_operator_addr,
+    // this uniquely identifies the corresponding EventClaimSettled.
+    int64 session_end_block_height = 8;
+
+    // Whether overservicing was triggered by per_session_spend_limit (true)
+    // vs the standard stake-based cap (false, default).
+    bool spend_limit_exceeded = 9;
 }
 
 // EventSupplierSlashed is emitted when a supplier is slashed.
@@ -232,6 +288,45 @@ message EventClaimDiscarded {
 
     // The operator address of the supplier whose claim was discarded.
     string supplier_operator_address = 7 [(cosmos_proto.scalar) = "cosmos.AddressString"];
+}
+
+// RewardDistributionDetail is a per-recipient, per-reason reward breakdown for a single claim.
+// Unlike the reward_distribution map (which merges all OpReasons per address),
+// this preserves the OpReason for each entry.
+message RewardDistributionDetail {
+    // The recipient address (bech32).
+    string recipient_address = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"];
+
+    // The settlement operation reason from the TLM.
+    SettlementOpReason op_reason = 2;
+
+    // The reward amount as a coin string (e.g. "1000upokt").
+    string amount = 3;
+}
+
+// EventSettlementBatch is emitted once per unique aggregated bank operation during settlement.
+// It provides the link between batched bank transfers and the settlement context.
+message EventSettlementBatch {
+    // The session end block height for the batch of settlements.
+    int64 session_end_block_height = 1;
+
+    // The sender module account (or destination module for mints/burns).
+    string sender_module = 2;
+
+    // The recipient (bech32 address for mod-to-acct, module name for mod-to-mod, empty for mints/burns).
+    string recipient = 3;
+
+    // The settlement operation reason from the TLM.
+    SettlementOpReason op_reason = 4;
+
+    // The total aggregated amount as a coin string.
+    string total_amount = 5;
+
+    // Number of individual claims that contributed to this batch.
+    uint32 num_claims = 6;
+
+    // The type of bank operation: "mint", "burn", "mod_to_mod", "mod_to_acct".
+    string op_type = 7;
 }
 
 // EventApplicationReimbursementRequest is emitted when an application requests a reimbursement from the DAO.

--- a/schema.graphql
+++ b/schema.graphql
@@ -122,6 +122,22 @@ enum SettlementOpReason {
   # Module accounting
   TLM_GLOBAL_MINT_SUPPLIER_SHAREHOLDER_REWARD_MODULE_TRANSFER
   TLM_GLOBAL_MINT_REIMBURSEMENT_REQUEST_ESCROW_MODULE_TRANSFER
+
+  # Relay Burn Equals Mint TLM reward distributions (post-aggregation)
+  TLM_RELAY_BURN_EQUALS_MINT_DAO_REWARD_DISTRIBUTION
+  # This label was truncated because it is too large to be handled by subql/postgres
+  TLM_RELAY_BURN_EQUALS_MINT_SOURCE_OWNER_RD # = TLM_RELAY_BURN_EQUALS_MINT_SOURCE_OWNER_REWARD_DISTRIBUTION
+  # This label was truncated because it is too large to be handled by subql/postgres
+  TLM_RELAY_BURN_EQUALS_MINT_APPLICATION_RD # = TLM_RELAY_BURN_EQUALS_MINT_APPLICATION_REWARD_DISTRIBUTION
+  TLM_RELAY_BURN_EQUALS_MINT_TOKENOMICS_MINT
+  # This label was truncated because it is too large to be handled by subql/postgres
+  TLM_RELAY_BURN_EQUALS_MINT_VALIDATOR_RD # = TLM_RELAY_BURN_EQUALS_MINT_VALIDATOR_REWARD_DISTRIBUTION
+  # This label was truncated because it is too large to be handled by subql/postgres
+  TLM_RELAY_BURN_EQUALS_MINT_DELEGATOR_RD # = TLM_RELAY_BURN_EQUALS_MINT_DELEGATOR_REWARD_DISTRIBUTION
+
+  # Global Mint TLM validator/delegator distributions (post-aggregation)
+  TLM_GLOBAL_MINT_VALIDATOR_REWARD_DISTRIBUTION
+  TLM_GLOBAL_MINT_DELEGATOR_REWARD_DISTRIBUTION
 }
 
 enum MorseSupplierClaimSignerType {
@@ -1007,6 +1023,18 @@ type EventClaimSettled @entity {
   burns: [MintBurnOp]!
   modToModTransfers: [ModToModTransfer]!
   block: Block!
+  # New fields from settlement aggregation (nullable for backward compat with pre-upgrade blocks)
+  settledAmount: BigInt
+  settledDenom: String
+  mintRatio: String
+  supplierOwner: Account
+  mintedAmount: BigInt
+  mintedDenom: String
+  overservicingLossAmount: BigInt
+  overservicingLossDenom: String
+  deflationLossAmount: BigInt
+  deflationLossDenom: String
+  rewardDistributionDetailed: [RewardDistributionDetail]
 }
 
 type MintBurnOp @jsonField(indexed: false) {
@@ -1024,6 +1052,25 @@ type ModToModTransfer @jsonField(indexed: false) {
   recipientModule: String!
   amount: BigInt!
   denom: String!
+}
+
+type RewardDistributionDetail @jsonField(indexed: false) {
+  recipientAddress: String!
+  opReason: Int!
+  amount: String!
+}
+
+type EventSettlementBatch @entity {
+  id: ID!
+  sessionEndBlockHeight: BigInt!
+  senderModule: String!
+  recipient: String!
+  opReason: SettlementOpReason!
+  totalAmount: BigInt!
+  totalAmountDenom: String!
+  numClaims: Int!
+  opType: String!
+  block: Block!
 }
 
 type EventProofUpdated @entity {
@@ -1067,6 +1114,10 @@ type EventApplicationOverserviced @entity {
   effectiveBurnDenom: String!
   block: Block!
   event: Event!
+  # New fields (nullable for backward compat with pre-upgrade blocks)
+  service: Service
+  sessionEndBlockHeight: BigInt
+  spendLimitExceeded: Boolean
 }
 
 type EventSupplierSlashed @entity {

--- a/schema.graphql
+++ b/schema.graphql
@@ -1053,54 +1053,6 @@ type ModToModTransfer @jsonField(indexed: false) {
   denom: String!
 }
 
-type RewardDistributionDetail @jsonField(indexed: false) {
-  recipientAddress: String!
-  opReason: Int!
-  amount: String!
-}
-
-type ModToAcctTransfer @entity {
-  id: ID!
-  eventClaimSettled: EventClaimSettled!
-  relay: Relay!
-  block: Block!
-  opReason: SettlementOpReason!
-  senderModule: String!
-  recipient: Account!
-  amount: BigInt!
-  denom: String!
-}
-
-type Relay @entity {
-  id: ID!
-  supplier: Supplier!
-  application: Application!
-  service: Service!
-  sessionId: String!
-  sessionStartHeight: BigInt!
-  sessionEndHeight: BigInt!
-  status: RelayStatus!
-  rootHash: String
-  closestMerkleProof: String
-  numRelays: BigInt
-  numClaimedComputedUnits: BigInt
-  numEstimatedComputedUnits: BigInt
-  claimedAmount: BigInt
-  claimedDenom: String
-  msgCreateClaim: MsgCreateClaim
-  msgSubmitProof: MsgSubmitProof
-  eventsClaimUpdated: [EventClaimUpdated] @derivedFrom(field: "relay")
-  eventClaimExpired: EventClaimExpired
-  eventClaimSettled: EventClaimSettled
-  eventsProofUpdated: [EventProofUpdated] @derivedFrom(field: "relay")
-  modToAcctTransfers: [ModToAcctTransfer]! @derivedFrom(field: "relay")
-  failedCodeSpace: String
-  requiredProof: Boolean
-  # this must be a value of the enums ClaimErrors or ProofErrors. We are using Int because we can't define enums with numbers.
-  failedCode: Int
-  proofValidationStatus: ClaimProofStatus
-}
-
 type EventProofUpdated @entity {
   id: ID!
   supplier: Supplier!

--- a/schema.graphql
+++ b/schema.graphql
@@ -1034,7 +1034,6 @@ type EventClaimSettled @entity {
   overservicingLossDenom: String
   deflationLossAmount: BigInt
   deflationLossDenom: String
-  rewardDistributionDetailed: [RewardDistributionDetail]
 }
 
 type MintBurnOp @jsonField(indexed: false) {
@@ -1060,17 +1059,46 @@ type RewardDistributionDetail @jsonField(indexed: false) {
   amount: String!
 }
 
-type EventSettlementBatch @entity {
+type ModToAcctTransfer @entity {
   id: ID!
-  sessionEndBlockHeight: BigInt!
-  senderModule: String!
-  recipient: String!
-  opReason: SettlementOpReason!
-  totalAmount: BigInt!
-  totalAmountDenom: String!
-  numClaims: Int!
-  opType: String!
+  eventClaimSettled: EventClaimSettled!
+  relay: Relay!
   block: Block!
+  opReason: SettlementOpReason!
+  senderModule: String!
+  recipient: Account!
+  amount: BigInt!
+  denom: String!
+}
+
+type Relay @entity {
+  id: ID!
+  supplier: Supplier!
+  application: Application!
+  service: Service!
+  sessionId: String!
+  sessionStartHeight: BigInt!
+  sessionEndHeight: BigInt!
+  status: RelayStatus!
+  rootHash: String
+  closestMerkleProof: String
+  numRelays: BigInt
+  numClaimedComputedUnits: BigInt
+  numEstimatedComputedUnits: BigInt
+  claimedAmount: BigInt
+  claimedDenom: String
+  msgCreateClaim: MsgCreateClaim
+  msgSubmitProof: MsgSubmitProof
+  eventsClaimUpdated: [EventClaimUpdated] @derivedFrom(field: "relay")
+  eventClaimExpired: EventClaimExpired
+  eventClaimSettled: EventClaimSettled
+  eventsProofUpdated: [EventProofUpdated] @derivedFrom(field: "relay")
+  modToAcctTransfers: [ModToAcctTransfer]! @derivedFrom(field: "relay")
+  failedCodeSpace: String
+  requiredProof: Boolean
+  # this must be a value of the enums ClaimErrors or ProofErrors. We are using Int because we can't define enums with numbers.
+  failedCode: Int
+  proofValidationStatus: ClaimProofStatus
 }
 
 type EventProofUpdated @entity {

--- a/src/mappings/dbFunctions/domainRewards.ts
+++ b/src/mappings/dbFunctions/domainRewards.ts
@@ -77,6 +77,9 @@ BEGIN
       ssc.service_id,
       COUNT(DISTINCT ssc.supplier_id) AS suppliers_count
     FROM ${dbSchema}.supplier_service_configs ssc
+    INNER JOIN ${dbSchema}.suppliers s ON s.id = ssc.supplier_id
+      AND s._block_range && v_block_range
+      AND s.stake_status = 'Staked'
     CROSS JOIN jsonb_array_elements_text(ssc.domains) AS domain
     WHERE ssc._block_range && v_block_range
       AND ssc.domains IS NOT NULL

--- a/src/mappings/dbFunctions/supply.ts
+++ b/src/mappings/dbFunctions/supply.ts
@@ -132,10 +132,13 @@ BEGIN
     AND b.timestamp BETWEEN start_date AND end_date;
 
   -- Mint by op_reason
+  -- Old protocol: opReason 1=SUPPLIER_STAKE_MINT (mint_burn), 3=INFLATION (inflation)
+  -- New protocol: opReason 19=TOKENOMICS_CLAIM_DISTRIBUTION_MINT (mint_burn), 5=DAO_REWARD_DISTRIBUTION (inflation)
+  -- opReason 10=REIMBURSEMENT_REQUEST_ESCROW_DAO_TRANSFER is unchanged across both protocols
   SELECT
     SUM(CASE WHEN (elem->>'opReason')::int = 10 THEN REPLACE(elem->>'amount', 'n', '')::numeric ELSE 0 END),
-    SUM(CASE WHEN (elem->>'opReason')::int = 3 THEN REPLACE(elem->>'amount', 'n', '')::numeric ELSE 0 END),
-    SUM(CASE WHEN (elem->>'opReason')::int = 1 THEN REPLACE(elem->>'amount', 'n', '')::numeric ELSE 0 END)
+    SUM(CASE WHEN (elem->>'opReason')::int IN (3, 5) THEN REPLACE(elem->>'amount', 'n', '')::numeric ELSE 0 END),
+    SUM(CASE WHEN (elem->>'opReason')::int IN (1, 19) THEN REPLACE(elem->>'amount', 'n', '')::numeric ELSE 0 END)
   INTO
     reimbursement_v2_amount, inflation_amount, mint_burn_amount
   FROM ${dbSchema}.event_claim_settleds t

--- a/src/mappings/handlers.ts
+++ b/src/mappings/handlers.ts
@@ -30,6 +30,7 @@ import {
   handleEventClaimUpdated,
   handleEventProofUpdated,
   handleEventProofValidityChecked,
+  handleEventSettlementBatch,
   handleMsgCreateClaim,
   handleMsgSubmitProof,
 } from "./pocket/relays";
@@ -124,6 +125,7 @@ export const EventHandlers: Record<string, (events: Array<CosmosEvent>) => Promi
   "pocket.tokenomics.EventSupplierSlashed": noOp, // - now handled in indexSupplier
   "pocket.tokenomics.EventApplicationOverserviced": handleEventApplicationOverserviced,
   "pocket.tokenomics.EventApplicationReimbursementRequest": handleEventApplicationReimbursementRequest,
+  "pocket.tokenomics.EventSettlementBatch": handleEventSettlementBatch,
   "pocket.proof.EventClaimUpdated": handleEventClaimUpdated,
   "pocket.proof.EventProofUpdated": handleEventProofUpdated,
   "pocket.proof.EventProofValidityChecked": handleEventProofValidityChecked,

--- a/src/mappings/handlers.ts
+++ b/src/mappings/handlers.ts
@@ -30,7 +30,6 @@ import {
   handleEventClaimUpdated,
   handleEventProofUpdated,
   handleEventProofValidityChecked,
-  handleEventSettlementBatch,
   handleMsgCreateClaim,
   handleMsgSubmitProof,
 } from "./pocket/relays";
@@ -125,7 +124,7 @@ export const EventHandlers: Record<string, (events: Array<CosmosEvent>) => Promi
   "pocket.tokenomics.EventSupplierSlashed": noOp, // - now handled in indexSupplier
   "pocket.tokenomics.EventApplicationOverserviced": handleEventApplicationOverserviced,
   "pocket.tokenomics.EventApplicationReimbursementRequest": handleEventApplicationReimbursementRequest,
-  "pocket.tokenomics.EventSettlementBatch": handleEventSettlementBatch,
+  "pocket.tokenomics.EventSettlementBatch": noOp, // we are not interested in this event
   "pocket.proof.EventClaimUpdated": handleEventClaimUpdated,
   "pocket.proof.EventProofUpdated": handleEventProofUpdated,
   "pocket.proof.EventProofValidityChecked": handleEventProofValidityChecked,

--- a/src/mappings/handlers.ts
+++ b/src/mappings/handlers.ts
@@ -30,6 +30,7 @@ import {
   handleEventClaimUpdated,
   handleEventProofUpdated,
   handleEventProofValidityChecked,
+  handleEventSettlementBatch,
   handleMsgCreateClaim,
   handleMsgSubmitProof,
 } from "./pocket/relays";
@@ -124,7 +125,7 @@ export const EventHandlers: Record<string, (events: Array<CosmosEvent>) => Promi
   "pocket.tokenomics.EventSupplierSlashed": noOp, // - now handled in indexSupplier
   "pocket.tokenomics.EventApplicationOverserviced": handleEventApplicationOverserviced,
   "pocket.tokenomics.EventApplicationReimbursementRequest": handleEventApplicationReimbursementRequest,
-  "pocket.tokenomics.EventSettlementBatch": noOp, // we are not interested in this event
+  "pocket.tokenomics.EventSettlementBatch": handleEventSettlementBatch,
   "pocket.proof.EventClaimUpdated": handleEventClaimUpdated,
   "pocket.proof.EventProofUpdated": handleEventProofUpdated,
   "pocket.proof.EventProofValidityChecked": handleEventProofValidityChecked,

--- a/src/mappings/indexer.manager.ts
+++ b/src/mappings/indexer.manager.ts
@@ -172,7 +172,8 @@ async function indexRelays(msgByType: MessageByType, eventByType: EventByType): 
     "pocket.proof.EventProofUpdated",
     "pocket.proof.EventProofValidityChecked",
     "pocket.tokenomics.EventApplicationOverserviced",
-    "pocket.tokenomics.EventApplicationReimbursementRequest"
+    "pocket.tokenomics.EventApplicationReimbursementRequest",
+    "pocket.tokenomics.EventSettlementBatch",
   ];
 
   await Promise.all([

--- a/src/mappings/pocket/relays.ts
+++ b/src/mappings/pocket/relays.ts
@@ -15,7 +15,6 @@ import {
 } from "../../types";
 import { EventApplicationOverservicedProps } from "../../types/models/EventApplicationOverserviced";
 import { EventApplicationReimbursementRequestProps } from "../../types/models/EventApplicationReimbursementRequest";
-import { EventSettlementBatchProps } from "../../types/models/EventSettlementBatch";
 import { EventClaimExpiredProps } from "../../types/models/EventClaimExpired";
 import { EventClaimSettledProps } from "../../types/models/EventClaimSettled";
 import { EventClaimUpdatedProps } from "../../types/models/EventClaimUpdated";
@@ -573,7 +572,7 @@ function _handleMsgSubmitProof(msg: CosmosMessage<MsgSubmitProof>): MsgSubmitPro
 }
 
 interface SettlementParts {
-  modToAcctTransfers: Array<ModToAcctTransferProps>;
+  modToAcctTransfers: Array<ModToAcctTransferRecord>;
   mints: EventClaimSettledProps["mints"];
   burns: EventClaimSettledProps["burns"];
   modToModTransfers: EventClaimSettledProps["modToModTransfers"];
@@ -701,19 +700,25 @@ function _buildSettlementFromDetailedDistribution(
   eventId: string,
   blockId: bigint,
   effectiveBurn: string,
-  mintRatio: number,
   claimed: CoinSDKType,
   mintedUpokt: CoinSDKType | undefined,
 ): SettlementParts {
-  let totalFromRewardDistribution = BigInt(0);
+  let inflationAmount = BigInt(0);
+  let reimbursementAmount = BigInt(0);
 
   const modToAcctTransfers = rewardDistributionDetailed.map((item, index) => {
     const coin = getDenomAndAmount(item.amount)
     const coinAmount = BigInt(coin.amount);
-    totalFromRewardDistribution = totalFromRewardDistribution + coinAmount;
+    const reason = getSettlementOpReasonFromSDK(item.op_reason);
+
+    if (reason === SettlementOpReason.TLM_GLOBAL_MINT_DAO_REWARD_DISTRIBUTION) {
+      inflationAmount += coinAmount;
+    } else if (reason === SettlementOpReason.TLM_GLOBAL_MINT_REIMBURSEMENT_REQUEST_ESCROW_DAO_TRANSFER) {
+      reimbursementAmount += coinAmount;
+    }
 
     return {
-      opReason: getSettlementOpReasonFromSDK(item.op_reason),
+      opReason: reason,
       amount: coinAmount,
       id: `${eventId}-${index}`,
       blockId,
@@ -725,8 +730,48 @@ function _buildSettlementFromDetailedDistribution(
     };
   });
 
-  const { burns, mintedUpokt: resolvedMintedUpokt, mints } =
-    _buildBurnsAndMintsFromRewardTotal(totalFromRewardDistribution, effectiveBurn, mintRatio, claimed, mintedUpokt);
+  const resolvedMintedUpokt: CoinSDKType = mintedUpokt || {
+    amount: effectiveBurn,
+    denom: claimed.denom,
+  };
+
+  const burns: EventClaimSettledProps["burns"] = [
+    {
+      opReason: settlementOpReasonFromJSON(SettlementOpReasonSdk.TLM_RELAY_BURN_EQUALS_MINT_APPLICATION_STAKE_BURN),
+      destinationModule: "",
+      amount: BigInt(effectiveBurn),
+      denom: claimed.denom,
+    },
+  ];
+
+  if (inflationAmount === BigInt(0)) {
+    throw new Error(`Missing TLM_GLOBAL_MINT_DAO_REWARD_DISTRIBUTION in reward_distribution_detailed for event ${eventId}`);
+  }
+
+  if (reimbursementAmount === BigInt(0)) {
+    throw new Error(`Missing TLM_GLOBAL_MINT_REIMBURSEMENT_REQUEST_ESCROW_DAO_TRANSFER in reward_distribution_detailed for event ${eventId}`);
+  }
+
+  const mints: EventClaimSettledProps["mints"] = [
+    {
+      opReason: settlementOpReasonFromJSON(SettlementOpReasonSdk.TLM_RELAY_BURN_EQUALS_MINT_TOKENOMICS_CLAIM_DISTRIBUTION_MINT),
+      destinationModule: "",
+      amount: BigInt(resolvedMintedUpokt.amount),
+      denom: claimed.denom,
+    },
+    {
+      opReason: settlementOpReasonFromJSON(SettlementOpReasonSdk.TLM_GLOBAL_MINT_DAO_REWARD_DISTRIBUTION),
+      destinationModule: "",
+      amount: inflationAmount,
+      denom: claimed.denom,
+    },
+    {
+      opReason: settlementOpReasonFromJSON(SettlementOpReasonSdk.TLM_GLOBAL_MINT_REIMBURSEMENT_REQUEST_ESCROW_DAO_TRANSFER),
+      destinationModule: "",
+      amount: reimbursementAmount,
+      denom: claimed.denom,
+    },
+  ];
 
   return { modToAcctTransfers, mints, burns, modToModTransfers: [], mintedUpokt: resolvedMintedUpokt };
 }
@@ -780,7 +825,7 @@ function _resolveSettlementParts(
 
   if (rewardDistributionDetailed) {
     return _buildSettlementFromDetailedDistribution(
-      rewardDistributionDetailed, eventId, blockId, effectiveBurn, mintRatio, claimed, mintedUpokt,
+      rewardDistributionDetailed, eventId, blockId, effectiveBurn, claimed, mintedUpokt,
     );
   }
 
@@ -894,7 +939,7 @@ function _handleEventClaimSettled(
   event: CosmosEvent,
   mintRatioFromParams: number,
   getEffectiveBurn: (application: string, supplier: string) => string | null
-): [EventClaimSettledProps, Array<ModToAcctTransferProps>] {
+): [EventClaimSettledProps, Array<ModToAcctTransferRecord>] {
   const attributes = getAttributes(event.event.attributes);
   const { claim, claimed, mintRatioStr, settledUpokt } = attributes;
 
@@ -1483,4 +1528,47 @@ export async function handleEventApplicationReimbursementRequest(events: Array<C
 
 export async function handleEventProofValidityChecked(events: Array<CosmosEvent>): Promise<void> {
   await optimizedBulkCreate("EventProofValidityChecked", events.map(_handleEventProofValidityChecked), 'block_id');
+}
+
+const VALIDATOR_REWARD_OP_REASONS = new Set([
+  "TLM_RELAY_BURN_EQUALS_MINT_VALIDATOR_REWARD_DISTRIBUTION",
+  "TLM_RELAY_BURN_EQUALS_MINT_DELEGATOR_REWARD_DISTRIBUTION",
+  "TLM_GLOBAL_MINT_VALIDATOR_REWARD_DISTRIBUTION",
+  "TLM_GLOBAL_MINT_DELEGATOR_REWARD_DISTRIBUTION",
+]);
+
+export async function handleEventSettlementBatch(events: Array<CosmosEvent>): Promise<void> {
+  const modToAcctTransfers: ModToAcctTransferRecord[] = [];
+
+  for (const event of events) {
+    let opType = '', opReason = '', recipient = '', totalAmount = '';
+
+    for (const attr of event.event.attributes) {
+      if (attr.key === 'op_type') opType = parseAttribute(attr.value);
+      if (attr.key === 'op_reason') opReason = parseAttribute(attr.value);
+      if (attr.key === 'recipient') recipient = parseAttribute(attr.value);
+      if (attr.key === 'total_amount') totalAmount = attr.value as string;
+    }
+
+    // Only process mod_to_acct transfers for validator/delegator rewards
+    if (opType !== 'mod_to_acct' || !VALIDATOR_REWARD_OP_REASONS.has(opReason)) continue;
+
+    const coin = getDenomAndAmount(totalAmount);
+    const eventId = getEventId(event);
+    const blockId = getBlockId(event.block);
+
+    modToAcctTransfers.push({
+      id: eventId,
+      eventClaimSettledId: '',
+      blockId,
+      opReason: getSettlementOpReasonFromSDK(opReason),
+      recipientId: recipient,
+      amount: BigInt(coin.amount),
+      denom: coin.denom,
+    });
+  }
+
+  if (modToAcctTransfers.length) {
+    await bulkInsertModToAcctTransfers(modToAcctTransfers);
+  }
 }

--- a/src/mappings/pocket/relays.ts
+++ b/src/mappings/pocket/relays.ts
@@ -572,31 +572,334 @@ function _handleMsgSubmitProof(msg: CosmosMessage<MsgSubmitProof>): MsgSubmitPro
   };
 }
 
-function _handleEventClaimSettled(
-  event: CosmosEvent,
+interface SettlementParts {
+  modToAcctTransfers: Array<ModToAcctTransferProps>;
+  mints: EventClaimSettledProps["mints"];
+  burns: EventClaimSettledProps["burns"];
+  modToModTransfers: EventClaimSettledProps["modToModTransfers"];
+  mintedUpokt: CoinSDKType | undefined;
+}
+
+// Builds burns and mints arrays from reward distribution totals.
+// Global mint is minted twice: once for inflation, once for application reimbursement.
+// See:
+//   https://github.com/pokt-network/poktroll/blob/main/x/tokenomics/token_logic_module/tlm_reimbursement_requests.go#L57
+//   https://github.com/pokt-network/poktroll/blob/main/x/tokenomics/token_logic_module/tlm_reimbursement_requests.go#L102-L112
+function _buildBurnsAndMintsFromRewardTotal(
+  totalFromRewardDistribution: bigint,
+  effectiveBurn: string,
   mintRatio: number,
-  getEffectiveBurn: (application: string, supplier: string) => string | null
-): [EventClaimSettledProps, Array<ModToAcctTransferRecord>] {
+  claimed: CoinSDKType,
+  mintedUpokt: CoinSDKType | undefined,
+): { burns: EventClaimSettledProps["burns"]; mints: EventClaimSettledProps["mints"]; mintedUpokt: CoinSDKType | undefined } {
+  const mintedAfterRatio = mintedUpokt ? Number(mintedUpokt.amount) : Math.floor(Number(effectiveBurn) * mintRatio);
+  const inflationPlusReimbursementMint = totalFromRewardDistribution - BigInt(mintedAfterRatio);
+
+  if (inflationPlusReimbursementMint < BigInt(0)) {
+    throw new Error(
+      `inflationAndReimbursementMint is negative, totalFromRewardDistribution: ${totalFromRewardDistribution}, claimed.amount: ${effectiveBurn}, inflationAndReimbursementMint: ${inflationPlusReimbursementMint}, mintRatio: ${mintRatio}`
+    )
+  }
+
+  const inflationAndReimbursementMint = inflationPlusReimbursementMint / BigInt(2);
+
+  const burns: EventClaimSettledProps["burns"] = [
+    {
+      opReason: settlementOpReasonFromJSON(SettlementOpReasonSdk.TLM_RELAY_BURN_EQUALS_MINT_APPLICATION_STAKE_BURN),
+      destinationModule: "",
+      amount: BigInt(effectiveBurn),
+      denom: claimed.denom,
+    },
+  ];
+
+  const mints: EventClaimSettledProps["mints"] = [
+    {
+      opReason: settlementOpReasonFromJSON(SettlementOpReasonSdk.TLM_GLOBAL_MINT_INFLATION),
+      destinationModule: "",
+      amount: inflationAndReimbursementMint,
+      denom: claimed.denom,
+    },
+    {
+      opReason: settlementOpReasonFromJSON(SettlementOpReasonSdk.TLM_GLOBAL_MINT_REIMBURSEMENT_REQUEST_ESCROW_DAO_TRANSFER),
+      destinationModule: "",
+      amount: inflationAndReimbursementMint,
+      denom: claimed.denom,
+    },
+    {
+      opReason: settlementOpReasonFromJSON(SettlementOpReasonSdk.TLM_RELAY_BURN_EQUALS_MINT_SUPPLIER_STAKE_MINT),
+      destinationModule: "",
+      amount: BigInt(mintedAfterRatio),
+      denom: claimed.denom,
+    },
+  ];
+
+  if (!mintedUpokt) {
+    mintedUpokt = {
+      amount: mintedAfterRatio.toString(),
+      denom: claimed.denom,
+    }
+  }
+
+  return { burns, mints, mintedUpokt };
+}
+
+function _buildSettlementFromResult(
+  settlementResult: ClaimSettlementResultSDKType,
+  eventId: string,
+  blockId: bigint,
+  effectiveBurn: string,
+  claimed: CoinSDKType,
+  mintedUpokt: CoinSDKType | undefined,
+): SettlementParts {
+  const modToAcctTransfers = settlementResult.mod_to_acct_transfers?.map((item, index) => ({
+    id: `${eventId}-${index}`,
+    blockId,
+    eventClaimSettledId: eventId,
+
+    recipientId: item.RecipientAddress,
+    amount: BigInt(item.coin.amount),
+    denom: item.coin.denom,
+    opReason: getSettlementOpReasonFromSDK(item.op_reason),
+
+  })) || [];
+
+  if (!mintedUpokt) {
+    // if we get settlementResult that means mintRatio is equal to 1, so the amount minted will be equal to the settled amount, to the effective burn too due to burn being equal to mint
+    mintedUpokt = {
+      amount: effectiveBurn,
+      denom: claimed.denom,
+    }
+  }
+
+  const mints = settlementResult.mints?.map(mint => ({
+    opReason: settlementOpReasonFromJSON(mint.op_reason),
+    destinationModule: mint.DestinationModule,
+    amount: BigInt(mint.coin.amount),
+    denom: mint.coin.denom,
+  })) || [];
+
+  const burns = settlementResult.burns?.map(burn => ({
+    opReason: settlementOpReasonFromJSON(burn.op_reason),
+    destinationModule: burn.DestinationModule,
+    amount: BigInt(burn.coin.amount),
+    denom: burn.coin.denom,
+  })) || [];
+
+  const modToModTransfers = settlementResult.mod_to_mod_transfers?.map((item) => ({
+    opReason: settlementOpReasonFromJSON(item.op_reason),
+    senderModule: item.SenderModule,
+    recipientModule: item.RecipientModule,
+    amount: BigInt(item.coin.amount),
+    denom: item.coin.denom,
+  })) || [];
+
+  return { modToAcctTransfers, mints, burns, modToModTransfers, mintedUpokt };
+}
+
+function _buildSettlementFromDetailedDistribution(
+  rewardDistributionDetailed: Array<{ amount: string; op_reason: typeof SettlementOpReasonSDKType | number | string; recipient_address: string }>,
+  eventId: string,
+  blockId: bigint,
+  effectiveBurn: string,
+  mintRatio: number,
+  claimed: CoinSDKType,
+  mintedUpokt: CoinSDKType | undefined,
+): SettlementParts {
+  let totalFromRewardDistribution = BigInt(0);
+
+  const modToAcctTransfers = rewardDistributionDetailed.map((item, index) => {
+    const coin = getDenomAndAmount(item.amount)
+    const coinAmount = BigInt(coin.amount);
+    totalFromRewardDistribution = totalFromRewardDistribution + coinAmount;
+
+    return {
+      opReason: getSettlementOpReasonFromSDK(item.op_reason),
+      amount: coinAmount,
+      id: `${eventId}-${index}`,
+      blockId,
+      eventClaimSettledId: eventId,
+      senderModule: "",
+      recipientId: item.recipient_address,
+      relayId: "",
+      denom: coin.denom,
+    };
+  });
+
+  const { burns, mintedUpokt: resolvedMintedUpokt, mints } =
+    _buildBurnsAndMintsFromRewardTotal(totalFromRewardDistribution, effectiveBurn, mintRatio, claimed, mintedUpokt);
+
+  return { modToAcctTransfers, mints, burns, modToModTransfers: [], mintedUpokt: resolvedMintedUpokt };
+}
+
+function _buildSettlementFromDistribution(
+  rewardDistribution: Record<string, string>,
+  eventId: string,
+  blockId: bigint,
+  effectiveBurn: string,
+  mintRatio: number,
+  claimed: CoinSDKType,
+): SettlementParts {
+  let totalFromRewardDistribution = BigInt(0);
+
+  const modToAcctTransfers = Object.entries(rewardDistribution).map(([address, coinString], index) => {
+    const coin = getDenomAndAmount(coinString);
+    const coinAmount = BigInt(coin.amount);
+    totalFromRewardDistribution = totalFromRewardDistribution + coinAmount;
+
+    return {
+      id: `${eventId}-${index}`,
+      blockId,
+      eventClaimSettledId: eventId,
+      senderModule: "",
+      recipientId: address,
+      opReason: SettlementOpReason.UNSPECIFIED,
+      relayId: "",
+      denom: coin.denom,
+      amount: coinAmount,
+    };
+  });
+
+  const { burns, mintedUpokt, mints } =
+    _buildBurnsAndMintsFromRewardTotal(totalFromRewardDistribution, effectiveBurn, mintRatio, claimed, undefined);
+
+  return { modToAcctTransfers, mints, burns, modToModTransfers: [], mintedUpokt };
+}
+
+function _resolveSettlementParts(
+  attributes: ReturnType<typeof getAttributes>,
+  eventId: string,
+  blockId: bigint,
+  effectiveBurn: string,
+  mintRatio: number,
+): SettlementParts {
+  const { claimed, mintedUpokt, rewardDistribution, rewardDistributionDetailed, settlementResult } = attributes;
+
+  if (settlementResult) {
+    return _buildSettlementFromResult(settlementResult, eventId, blockId, effectiveBurn, claimed, mintedUpokt);
+  }
+
+  if (rewardDistributionDetailed) {
+    return _buildSettlementFromDetailedDistribution(
+      rewardDistributionDetailed, eventId, blockId, effectiveBurn, mintRatio, claimed, mintedUpokt,
+    );
+  }
+
+  if (rewardDistribution) {
+    return _buildSettlementFromDistribution(rewardDistribution, eventId, blockId, effectiveBurn, mintRatio, claimed);
+  }
+
+  return { modToAcctTransfers: [], mints: [], burns: [], modToModTransfers: [], mintedUpokt };
+}
+
+function _computeNumEstimatedRelays(
+  chainNumEstimatedRelays: bigint | undefined,
+  numEstimatedComputedUnits: bigint,
+  numClaimedComputedUnits: bigint,
+  numRelays: bigint,
+): bigint {
+  if (chainNumEstimatedRelays !== undefined) {
+    return chainNumEstimatedRelays;
+  }
+  return BigInt(Math.round(Number(numEstimatedComputedUnits) / Math.floor(Number(numClaimedComputedUnits) / Number(numRelays))));
+}
+
+function _computeDeflationLoss(
+  deflationLossUpokt: CoinSDKType | undefined,
+  effectiveBurn: string,
+  mintedUpokt: CoinSDKType | undefined,
+): bigint {
+  return deflationLossUpokt
+    ? BigInt(deflationLossUpokt.amount)
+    : BigInt(effectiveBurn) - BigInt(mintedUpokt?.amount || 0);
+}
+
+function _computeOverservicingLoss(
+  overservicingLossUpokt: CoinSDKType | undefined,
+  claimedAmount: string,
+  effectiveBurn: string,
+): bigint {
+  if (overservicingLossUpokt) {
+    return BigInt(overservicingLossUpokt.amount);
+  }
+  return claimedAmount !== effectiveBurn
+    ? BigInt(claimedAmount) - BigInt(effectiveBurn)
+    : BigInt(0);
+}
+
+function _buildClaimSettledProps(
+  event: CosmosEvent,
+  attributes: ReturnType<typeof getAttributes>,
+  settlement: SettlementParts,
+  effectiveBurn: string,
+  mintRatio: number,
+): EventClaimSettledProps {
   const {
+    chainNumEstimatedRelays,
     claim,
     claimed,
+    deflationLossUpokt,
     numClaimedComputedUnits,
     numEstimatedComputedUnits,
     numRelays,
-    proofRequirement,
-    rewardDistribution,
-    rewardDistributionDetailed,
-    settlementResult,
-    settledUpokt,
-    mintRatioStr,
-    supplierOwnerAddress,
-    chainNumEstimatedRelays,
-    mintedUpokt,
     overservicingLossUpokt,
-    deflationLossUpokt,
-  } = getAttributes(event.event.attributes);
-
+    proofRequirement,
+    settledUpokt,
+    supplierOwnerAddress,
+  } = attributes;
   const { proof_validation_status, session_header, supplier_operator_address } = claim;
+  const { burns, mintedUpokt, mints, modToModTransfers } = settlement;
+
+  const numEstimatedRelays = _computeNumEstimatedRelays(
+    chainNumEstimatedRelays, numEstimatedComputedUnits, numClaimedComputedUnits, numRelays,
+  );
+  const overservicingLossAmount = _computeOverservicingLoss(overservicingLossUpokt, claimed.amount, effectiveBurn);
+  const deflationLossAmount = _computeDeflationLoss(deflationLossUpokt, effectiveBurn, mintedUpokt);
+
+  return {
+    supplierId: supplier_operator_address,
+    applicationId: session_header?.application_address || "",
+    serviceId: session_header?.service_id || "",
+    sessionId: session_header?.session_id || "",
+    sessionStartHeight: BigInt(session_header?.session_start_block_height?.toString() || 0),
+    sessionEndHeight: BigInt(session_header?.session_end_block_height?.toString() || 0),
+    numRelays,
+    numEstimatedRelays,
+    numClaimedComputedUnits,
+    numEstimatedComputedUnits,
+    claimedDenom: claimed?.denom || "",
+    claimedAmount: BigInt(effectiveBurn || "0"),
+    proofValidationStatus: getClaimProofStatusFromSDK(proof_validation_status),
+    transactionId: event.tx?.hash,
+    blockId: getBlockId(event.block),
+    id: getEventId(event),
+    proofRequirement,
+    mints,
+    burns,
+    modToModTransfers,
+    rootHash: undefined,
+    settledAmount: BigInt(effectiveBurn),
+    settledDenom: settledUpokt?.denom || claimed.denom,
+    mintRatio: mintRatio.toString(),
+    supplierOwnerId: supplierOwnerAddress,
+    mintedAmount: mintedUpokt ? BigInt(mintedUpokt.amount) : undefined,
+    mintedDenom: mintedUpokt?.denom || claimed.denom,
+    overservicingLossAmount: overservicingLossAmount,
+    overservicingLossDenom: overservicingLossUpokt?.denom || claimed.denom,
+    deflationLossAmount: deflationLossAmount,
+    deflationLossDenom: deflationLossUpokt?.denom || claimed.denom,
+  };
+}
+
+function _handleEventClaimSettled(
+  event: CosmosEvent,
+  mintRatioFromParams: number,
+  getEffectiveBurn: (application: string, supplier: string) => string | null
+): [EventClaimSettledProps, Array<ModToAcctTransferProps>] {
+  const attributes = getAttributes(event.event.attributes);
+  const { claim, claimed, mintRatioStr, settledUpokt } = attributes;
+
+  const mintRatio = mintRatioStr ? parseFloat(mintRatioStr) : mintRatioFromParams;
+  const { session_header, supplier_operator_address } = claim;
 
   const eventId = getEventId(event);
   const blockId = getBlockId(event.block);
@@ -605,165 +908,12 @@ function _handleEventClaimSettled(
   // otherwise fall back to overserviced effective_burn, then claimed amount
   const effectiveBurn = settledUpokt
     ? settledUpokt.amount
-    : (getEffectiveBurn(session_header?.application_address || "", supplier_operator_address) || claimed.amount)
+    : (getEffectiveBurn(session_header?.application_address || "", supplier_operator_address) || claimed.amount);
 
-  let
-    modToAcctTransfers: Array<ModToAcctTransferRecord> = [],
-    mints: EventClaimSettledProps["mints"] = [],
-    burns: EventClaimSettledProps["burns"] = [],
-    modToModTransfers: EventClaimSettledProps["modToModTransfers"] = [];
+  const settlement = _resolveSettlementParts(attributes, eventId, blockId, effectiveBurn, mintRatio);
+  const props = _buildClaimSettledProps(event, attributes, settlement, effectiveBurn, mintRatio);
 
-  if (settlementResult) {
-    modToAcctTransfers = settlementResult.mod_to_acct_transfers?.map((item, index) => ({
-      id: `${eventId}-${index}`,
-      blockId,
-      eventClaimSettledId: eventId,
-      recipientId: item.RecipientAddress,
-      amount: BigInt(item.coin.amount),
-      denom: item.coin.denom,
-      opReason: getSettlementOpReasonFromSDK(item.op_reason),
-    })) || [];
-
-    mints = settlementResult.mints?.map(mint => ({
-      opReason: settlementOpReasonFromJSON(mint.op_reason),
-      destinationModule: mint.DestinationModule,
-      amount: BigInt(mint.coin.amount),
-      denom: mint.coin.denom,
-    })) || [];
-
-    burns = settlementResult.burns?.map(burn => ({
-      opReason: settlementOpReasonFromJSON(burn.op_reason),
-      destinationModule: burn.DestinationModule,
-      amount: BigInt(burn.coin.amount),
-      denom: burn.coin.denom,
-    })) || [];
-
-    modToModTransfers = settlementResult.mod_to_mod_transfers?.map((item) => ({
-      opReason: settlementOpReasonFromJSON(item.op_reason),
-      senderModule: item.SenderModule,
-      recipientModule: item.RecipientModule,
-      amount: BigInt(item.coin.amount),
-      denom: item.coin.denom,
-    })) || [];
-  } else if (rewardDistribution) {
-    let totalFromRewardDistribution = BigInt(0);
-
-    modToAcctTransfers = Object.entries(rewardDistribution).map(([address, coinString], index) => {
-      const coin = getDenomAndAmount(coinString);
-      const coinAmount = BigInt(coin.amount);
-      totalFromRewardDistribution = totalFromRewardDistribution + coinAmount;
-
-      return {
-        id: `${eventId}-${index}`,
-        blockId,
-        eventClaimSettledId: eventId,
-        senderModule: "",
-        recipientId: address,
-        opReason: SettlementOpReason.UNSPECIFIED,
-        relayId: "",
-        denom: coin.denom,
-        amount: coinAmount,
-      };
-    });
-
-    // it seems that global mint is being minted twice, one due to inflation and the other due to application reimbursement
-    // see:
-    //      https://github.com/pokt-network/poktroll/blob/main/x/tokenomics/token_logic_module/tlm_reimbursement_requests.go#L57
-    //      https://github.com/pokt-network/poktroll/blob/main/x/tokenomics/token_logic_module/tlm_reimbursement_requests.go#L102-L112
-    // so in order to get the inflation mint, we need to divide the difference between the total of the reward_distribution
-    // and the claimed upokt
-    const mintedAfterRatio = Math.floor(Number(effectiveBurn) * mintRatio);
-    const inflationPlusReimbursementMint = totalFromRewardDistribution - BigInt(mintedAfterRatio);
-
-    if (inflationPlusReimbursementMint < BigInt(0)) {
-      throw new Error(
-        `inflationAndReimbursementMint is negative, totalFromRewardDistribution: ${totalFromRewardDistribution}, claimed.amount: ${effectiveBurn}, inflationAndReimbursementMint: ${inflationPlusReimbursementMint}, mintRatio: ${mintRatio}`
-      )
-    }
-
-    const inflationAndReimbursementMint = inflationPlusReimbursementMint / BigInt(2);
-
-    burns = [
-      {
-        opReason: settlementOpReasonFromJSON(SettlementOpReasonSdk.TLM_RELAY_BURN_EQUALS_MINT_APPLICATION_STAKE_BURN),
-        destinationModule: "",
-        amount: BigInt(effectiveBurn),
-        denom: claimed.denom,
-      },
-    ];
-
-    mints = [
-      {
-        opReason: settlementOpReasonFromJSON(SettlementOpReasonSdk.TLM_GLOBAL_MINT_INFLATION),
-        destinationModule: "",
-        amount: inflationAndReimbursementMint,
-        denom: claimed.denom,
-      },
-      {
-        opReason: settlementOpReasonFromJSON(SettlementOpReasonSdk.TLM_GLOBAL_MINT_REIMBURSEMENT_REQUEST_ESCROW_DAO_TRANSFER),
-        destinationModule: "",
-        amount: inflationAndReimbursementMint,
-        denom: claimed.denom,
-      },
-      {
-        opReason: settlementOpReasonFromJSON(SettlementOpReasonSdk.TLM_RELAY_BURN_EQUALS_MINT_SUPPLIER_STAKE_MINT),
-        destinationModule: "",
-        amount: BigInt(mintedAfterRatio),
-        denom: claimed.denom,
-      },
-    ];
-  }
-
-  // Use chain-provided num_estimated_relays if available, otherwise compute from CU ratio
-  const numEstimatedRelays = chainNumEstimatedRelays !== undefined
-    ? chainNumEstimatedRelays
-    : BigInt(Math.round(Number(numEstimatedComputedUnits) / Math.floor(Number(numClaimedComputedUnits) / Number(numRelays))));
-
-  // Map reward_distribution_detailed to the schema's RewardDistributionDetail JSON type
-  const mappedRewardDistributionDetailed = rewardDistributionDetailed?.map(detail => ({
-    recipientAddress: detail.recipient_address,
-    opReason: detail.op_reason,
-    amount: detail.amount,
-  }));
-
-  return [
-    {
-      supplierId: supplier_operator_address,
-      applicationId: session_header?.application_address || "",
-      serviceId: session_header?.service_id || "",
-      sessionId: session_header?.session_id || "",
-      sessionStartHeight: BigInt(session_header?.session_start_block_height?.toString() || 0),
-      sessionEndHeight: BigInt(session_header?.session_end_block_height?.toString() || 0),
-      numRelays,
-      numEstimatedRelays,
-      numClaimedComputedUnits,
-      numEstimatedComputedUnits,
-      claimedDenom: claimed?.denom || "",
-      claimedAmount: BigInt(effectiveBurn || "0"),
-      proofValidationStatus: getClaimProofStatusFromSDK(proof_validation_status),
-      transactionId: event.tx?.hash,
-      blockId: blockId,
-      id: eventId,
-      proofRequirement,
-      mints,
-      burns,
-      modToModTransfers,
-      rootHash: undefined,
-      // New fields from settlement aggregation (undefined for pre-upgrade blocks)
-      settledAmount: settledUpokt ? BigInt(settledUpokt.amount) : undefined,
-      settledDenom: settledUpokt?.denom,
-      mintRatio: mintRatioStr,
-      supplierOwnerId: supplierOwnerAddress,
-      mintedAmount: mintedUpokt ? BigInt(mintedUpokt.amount) : undefined,
-      mintedDenom: mintedUpokt?.denom,
-      overservicingLossAmount: overservicingLossUpokt ? BigInt(overservicingLossUpokt.amount) : undefined,
-      overservicingLossDenom: overservicingLossUpokt?.denom,
-      deflationLossAmount: deflationLossUpokt ? BigInt(deflationLossUpokt.amount) : undefined,
-      deflationLossDenom: deflationLossUpokt?.denom,
-      rewardDistributionDetailed: mappedRewardDistributionDetailed,
-    },
-    modToAcctTransfers,
-  ];
+  return [props, settlement.modToAcctTransfers];
 }
 
 function _handleEventClaimExpired(event: CosmosEvent): EventClaimExpiredProps {
@@ -1333,61 +1483,4 @@ export async function handleEventApplicationReimbursementRequest(events: Array<C
 
 export async function handleEventProofValidityChecked(events: Array<CosmosEvent>): Promise<void> {
   await optimizedBulkCreate("EventProofValidityChecked", events.map(_handleEventProofValidityChecked), 'block_id');
-}
-
-function _handleEventSettlementBatch(event: CosmosEvent): EventSettlementBatchProps {
-  let sessionEndBlockHeight = BigInt(0),
-    senderModule = "",
-    recipient = "",
-    opReasonValue: string | number = 0,
-    totalAmountCoin: CoinSDKType | undefined,
-    numClaims = 0,
-    opType = "";
-
-  for (const attribute of event.event.attributes) {
-    if (attribute.key === "session_end_block_height") {
-      sessionEndBlockHeight = BigInt(parseAttribute(attribute.value));
-    }
-
-    if (attribute.key === "sender_module") {
-      senderModule = parseAttribute(attribute.value);
-    }
-
-    if (attribute.key === "recipient") {
-      recipient = parseAttribute(attribute.value);
-    }
-
-    if (attribute.key === "op_reason") {
-      opReasonValue = parseAttribute(attribute.value);
-    }
-
-    if (attribute.key === "total_amount") {
-      totalAmountCoin = getDenomAndAmount(attribute.value as string);
-    }
-
-    if (attribute.key === "num_claims") {
-      numClaims = Number(parseAttribute(attribute.value));
-    }
-
-    if (attribute.key === "op_type") {
-      opType = parseAttribute(attribute.value);
-    }
-  }
-
-  return {
-    id: getEventId(event),
-    sessionEndBlockHeight,
-    senderModule,
-    recipient,
-    opReason: getSettlementOpReasonFromSDK(opReasonValue),
-    totalAmount: totalAmountCoin ? BigInt(totalAmountCoin.amount) : BigInt(0),
-    totalAmountDenom: totalAmountCoin?.denom || "",
-    numClaims,
-    opType,
-    blockId: getBlockId(event.block),
-  };
-}
-
-export async function handleEventSettlementBatch(events: Array<CosmosEvent>): Promise<void> {
-  await optimizedBulkCreate("EventSettlementBatch", events.map(_handleEventSettlementBatch), 'block_id');
 }

--- a/src/mappings/pocket/relays.ts
+++ b/src/mappings/pocket/relays.ts
@@ -15,6 +15,7 @@ import {
 } from "../../types";
 import { EventApplicationOverservicedProps } from "../../types/models/EventApplicationOverserviced";
 import { EventApplicationReimbursementRequestProps } from "../../types/models/EventApplicationReimbursementRequest";
+import { EventSettlementBatchProps } from "../../types/models/EventSettlementBatch";
 import { EventClaimExpiredProps } from "../../types/models/EventClaimExpired";
 import { EventClaimSettledProps } from "../../types/models/EventClaimSettled";
 import { EventClaimUpdatedProps } from "../../types/models/EventClaimUpdated";
@@ -160,6 +161,38 @@ function getSettlementOpReasonFromSDK(item: typeof SettlementOpReasonSDKType | n
     case SettlementOpReasonSDKType.TLM_GLOBAL_MINT_REIMBURSEMENT_REQUEST_ESCROW_MODULE_TRANSFER:
       return SettlementOpReason.TLM_GLOBAL_MINT_REIMBURSEMENT_REQUEST_ESCROW_MODULE_TRANSFER;
 
+    case "TLM_RELAY_BURN_EQUALS_MINT_DAO_REWARD_DISTRIBUTION":
+    case SettlementOpReasonSDKType.TLM_RELAY_BURN_EQUALS_MINT_DAO_REWARD_DISTRIBUTION:
+      return SettlementOpReason.TLM_RELAY_BURN_EQUALS_MINT_DAO_REWARD_DISTRIBUTION;
+
+    case "TLM_RELAY_BURN_EQUALS_MINT_SOURCE_OWNER_REWARD_DISTRIBUTION":
+    case SettlementOpReasonSDKType.TLM_RELAY_BURN_EQUALS_MINT_SOURCE_OWNER_REWARD_DISTRIBUTION:
+      return SettlementOpReason.TLM_RELAY_BURN_EQUALS_MINT_SOURCE_OWNER_RD;
+
+    case "TLM_RELAY_BURN_EQUALS_MINT_APPLICATION_REWARD_DISTRIBUTION":
+    case SettlementOpReasonSDKType.TLM_RELAY_BURN_EQUALS_MINT_APPLICATION_REWARD_DISTRIBUTION:
+      return SettlementOpReason.TLM_RELAY_BURN_EQUALS_MINT_APPLICATION_RD;
+
+    case "TLM_RELAY_BURN_EQUALS_MINT_TOKENOMICS_CLAIM_DISTRIBUTION_MINT":
+    case SettlementOpReasonSDKType.TLM_RELAY_BURN_EQUALS_MINT_TOKENOMICS_CLAIM_DISTRIBUTION_MINT:
+      return SettlementOpReason.TLM_RELAY_BURN_EQUALS_MINT_TOKENOMICS_MINT;
+
+    case "TLM_RELAY_BURN_EQUALS_MINT_VALIDATOR_REWARD_DISTRIBUTION":
+    case SettlementOpReasonSDKType.TLM_RELAY_BURN_EQUALS_MINT_VALIDATOR_REWARD_DISTRIBUTION:
+      return SettlementOpReason.TLM_RELAY_BURN_EQUALS_MINT_VALIDATOR_RD;
+
+    case "TLM_RELAY_BURN_EQUALS_MINT_DELEGATOR_REWARD_DISTRIBUTION":
+    case SettlementOpReasonSDKType.TLM_RELAY_BURN_EQUALS_MINT_DELEGATOR_REWARD_DISTRIBUTION:
+      return SettlementOpReason.TLM_RELAY_BURN_EQUALS_MINT_DELEGATOR_RD;
+
+    case "TLM_GLOBAL_MINT_VALIDATOR_REWARD_DISTRIBUTION":
+    case SettlementOpReasonSDKType.TLM_GLOBAL_MINT_VALIDATOR_REWARD_DISTRIBUTION:
+      return SettlementOpReason.TLM_GLOBAL_MINT_VALIDATOR_REWARD_DISTRIBUTION;
+
+    case "TLM_GLOBAL_MINT_DELEGATOR_REWARD_DISTRIBUTION":
+    case SettlementOpReasonSDKType.TLM_GLOBAL_MINT_DELEGATOR_REWARD_DISTRIBUTION:
+      return SettlementOpReason.TLM_GLOBAL_MINT_DELEGATOR_REWARD_DISTRIBUTION;
+
     default:
       return SettlementOpReason.UNSPECIFIED;
   }
@@ -192,7 +225,15 @@ export function getAttributes(attributes: CosmosEvent["event"]["attributes"]) {
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
     proofMissingPenalty: CoinSDKType = {},
-    rewardDistribution: Record<string, string> | undefined;
+    rewardDistribution: Record<string, string> | undefined,
+    rewardDistributionDetailed: Array<{ recipient_address: string; op_reason: number; amount: string }> | undefined,
+    settledUpokt: CoinSDKType | undefined,
+    mintRatioStr: string | undefined,
+    supplierOwnerAddress: string | undefined,
+    chainNumEstimatedRelays: bigint | undefined,
+    mintedUpokt: CoinSDKType | undefined,
+    overservicingLossUpokt: CoinSDKType | undefined,
+    deflationLossUpokt: CoinSDKType | undefined;
 
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore
@@ -222,7 +263,13 @@ export function getAttributes(attributes: CosmosEvent["event"]["attributes"]) {
     if (attribute.key === "session_end_block_height") {
       newClaim.session_header!.session_end_block_height = BigInt(parseAttribute(attribute.value));
       newClaim.session_header!.session_start_block_height = BigInt(0);
-      newClaim.session_header!.session_id = "";
+      if (!newClaim.session_header!.session_id) {
+        newClaim.session_header!.session_id = "";
+      }
+    }
+
+    if (attribute.key === "session_id") {
+      newClaim.session_header!.session_id = parseAttribute(attribute.value);
     }
 
     if (attribute.key === "claim_proof_status_int") {
@@ -257,6 +304,38 @@ export function getAttributes(attributes: CosmosEvent["event"]["attributes"]) {
 
     if (attribute.key === "reward_distribution") {
       rewardDistribution = JSON.parse(attribute.value as string);
+    }
+
+    if (attribute.key === "reward_distribution_detailed") {
+      rewardDistributionDetailed = JSON.parse(attribute.value as string);
+    }
+
+    if (attribute.key === "settled_upokt") {
+      settledUpokt = getDenomAndAmount(attribute.value as string);
+    }
+
+    if (attribute.key === "mint_ratio") {
+      mintRatioStr = parseAttribute(attribute.value);
+    }
+
+    if (attribute.key === "supplier_owner_address") {
+      supplierOwnerAddress = parseAttribute(attribute.value);
+    }
+
+    if (attribute.key === "num_estimated_relays") {
+      chainNumEstimatedRelays = BigInt(parseAttribute(attribute.value));
+    }
+
+    if (attribute.key === "minted_upokt") {
+      mintedUpokt = getDenomAndAmount(attribute.value as string);
+    }
+
+    if (attribute.key === "overservicing_loss_upokt") {
+      overservicingLossUpokt = getDenomAndAmount(attribute.value as string);
+    }
+
+    if (attribute.key === "deflation_loss_upokt") {
+      deflationLossUpokt = getDenomAndAmount(attribute.value as string);
     }
 
     if (attribute.key === "proof_missing_penalty") {
@@ -328,6 +407,14 @@ export function getAttributes(attributes: CosmosEvent["event"]["attributes"]) {
     proofValidationStatus,
     settlementResult,
     rewardDistribution,
+    rewardDistributionDetailed,
+    settledUpokt,
+    mintRatioStr,
+    supplierOwnerAddress,
+    chainNumEstimatedRelays,
+    mintedUpokt,
+    overservicingLossUpokt,
+    deflationLossUpokt,
   };
 }
 
@@ -498,7 +585,15 @@ function _handleEventClaimSettled(
     numRelays,
     proofRequirement,
     rewardDistribution,
+    rewardDistributionDetailed,
     settlementResult,
+    settledUpokt,
+    mintRatioStr,
+    supplierOwnerAddress,
+    chainNumEstimatedRelays,
+    mintedUpokt,
+    overservicingLossUpokt,
+    deflationLossUpokt,
   } = getAttributes(event.event.attributes);
 
   const { proof_validation_status, session_header, supplier_operator_address } = claim;
@@ -506,9 +601,11 @@ function _handleEventClaimSettled(
   const eventId = getEventId(event);
   const blockId = getBlockId(event.block);
 
-  // We need to see if there is an EventApplicationOverserviced event with effective_burn to use instead of claimed.amount
-  // because if this event exists for this session, it means less was paid
-  const effectiveBurn = getEffectiveBurn(session_header?.application_address || "", supplier_operator_address) || claimed.amount
+  // Use chain-provided settled_upokt if available (post-aggregation upgrade),
+  // otherwise fall back to overserviced effective_burn, then claimed amount
+  const effectiveBurn = settledUpokt
+    ? settledUpokt.amount
+    : (getEffectiveBurn(session_header?.application_address || "", supplier_operator_address) || claimed.amount)
 
   let
     modToAcctTransfers: Array<ModToAcctTransferRecord> = [],
@@ -617,8 +714,17 @@ function _handleEventClaimSettled(
     ];
   }
 
-  const CUPR = Math.floor(Number(numClaimedComputedUnits) / Number(numRelays))
-  const numEstimatedRelays = BigInt(Math.round(Number(numEstimatedComputedUnits) / CUPR))
+  // Use chain-provided num_estimated_relays if available, otherwise compute from CU ratio
+  const numEstimatedRelays = chainNumEstimatedRelays !== undefined
+    ? chainNumEstimatedRelays
+    : BigInt(Math.round(Number(numEstimatedComputedUnits) / Math.floor(Number(numClaimedComputedUnits) / Number(numRelays))));
+
+  // Map reward_distribution_detailed to the schema's RewardDistributionDetail JSON type
+  const mappedRewardDistributionDetailed = rewardDistributionDetailed?.map(detail => ({
+    recipientAddress: detail.recipient_address,
+    opReason: detail.op_reason,
+    amount: detail.amount,
+  }));
 
   return [
     {
@@ -643,6 +749,18 @@ function _handleEventClaimSettled(
       burns,
       modToModTransfers,
       rootHash: undefined,
+      // New fields from settlement aggregation (undefined for pre-upgrade blocks)
+      settledAmount: settledUpokt ? BigInt(settledUpokt.amount) : undefined,
+      settledDenom: settledUpokt?.denom,
+      mintRatio: mintRatioStr,
+      supplierOwnerId: supplierOwnerAddress,
+      mintedAmount: mintedUpokt ? BigInt(mintedUpokt.amount) : undefined,
+      mintedDenom: mintedUpokt?.denom,
+      overservicingLossAmount: overservicingLossUpokt ? BigInt(overservicingLossUpokt.amount) : undefined,
+      overservicingLossDenom: overservicingLossUpokt?.denom,
+      deflationLossAmount: deflationLossUpokt ? BigInt(deflationLossUpokt.amount) : undefined,
+      deflationLossDenom: deflationLossUpokt?.denom,
+      rewardDistributionDetailed: mappedRewardDistributionDetailed,
     },
     modToAcctTransfers,
   ];
@@ -823,6 +941,9 @@ function _handleEventProofUpdated(event: CosmosEvent): EventProofUpdatedProps {
 function _handleEventApplicationOverserviced(event: CosmosEvent): EventApplicationOverservicedProps {
   let expectedBurn: Coin | null = null, effectiveBurn: Coin | null = null, applicationAddress = "",
     supplierAddress = "";
+  let serviceId: string | undefined;
+  let sessionEndBlockHeight: bigint | undefined;
+  let spendLimitExceeded: boolean | undefined;
 
   for (const attribute of event.event.attributes) {
     if (attribute.key === "application_addr") {
@@ -839,6 +960,18 @@ function _handleEventApplicationOverserviced(event: CosmosEvent): EventApplicati
 
     if (attribute.key === "effective_burn") {
       effectiveBurn = getDenomAndAmount(attribute.value as string);
+    }
+
+    if (attribute.key === "service_id") {
+      serviceId = parseAttribute(attribute.value);
+    }
+
+    if (attribute.key === "session_end_block_height") {
+      sessionEndBlockHeight = BigInt(parseAttribute(attribute.value));
+    }
+
+    if (attribute.key === "spend_limit_exceeded") {
+      spendLimitExceeded = parseAttribute(attribute.value) === "true";
     }
   }
 
@@ -868,6 +1001,10 @@ function _handleEventApplicationOverserviced(event: CosmosEvent): EventApplicati
     effectiveBurnDenom: effectiveBurn.denom,
     blockId: getBlockId(event.block),
     eventId: getEventId(event),
+    // New fields (undefined for pre-upgrade blocks)
+    serviceId,
+    sessionEndBlockHeight,
+    spendLimitExceeded,
   };
 }
 
@@ -1196,4 +1333,61 @@ export async function handleEventApplicationReimbursementRequest(events: Array<C
 
 export async function handleEventProofValidityChecked(events: Array<CosmosEvent>): Promise<void> {
   await optimizedBulkCreate("EventProofValidityChecked", events.map(_handleEventProofValidityChecked), 'block_id');
+}
+
+function _handleEventSettlementBatch(event: CosmosEvent): EventSettlementBatchProps {
+  let sessionEndBlockHeight = BigInt(0),
+    senderModule = "",
+    recipient = "",
+    opReasonValue: string | number = 0,
+    totalAmountCoin: CoinSDKType | undefined,
+    numClaims = 0,
+    opType = "";
+
+  for (const attribute of event.event.attributes) {
+    if (attribute.key === "session_end_block_height") {
+      sessionEndBlockHeight = BigInt(parseAttribute(attribute.value));
+    }
+
+    if (attribute.key === "sender_module") {
+      senderModule = parseAttribute(attribute.value);
+    }
+
+    if (attribute.key === "recipient") {
+      recipient = parseAttribute(attribute.value);
+    }
+
+    if (attribute.key === "op_reason") {
+      opReasonValue = parseAttribute(attribute.value);
+    }
+
+    if (attribute.key === "total_amount") {
+      totalAmountCoin = getDenomAndAmount(attribute.value as string);
+    }
+
+    if (attribute.key === "num_claims") {
+      numClaims = Number(parseAttribute(attribute.value));
+    }
+
+    if (attribute.key === "op_type") {
+      opType = parseAttribute(attribute.value);
+    }
+  }
+
+  return {
+    id: getEventId(event),
+    sessionEndBlockHeight,
+    senderModule,
+    recipient,
+    opReason: getSettlementOpReasonFromSDK(opReasonValue),
+    totalAmount: totalAmountCoin ? BigInt(totalAmountCoin.amount) : BigInt(0),
+    totalAmountDenom: totalAmountCoin?.denom || "",
+    numClaims,
+    opType,
+    blockId: getBlockId(event.block),
+  };
+}
+
+export async function handleEventSettlementBatch(events: Array<CosmosEvent>): Promise<void> {
+  await optimizedBulkCreate("EventSettlementBatch", events.map(_handleEventSettlementBatch), 'block_id');
 }

--- a/src/mappings/pocket/relays.ts
+++ b/src/mappings/pocket/relays.ts
@@ -1569,6 +1569,10 @@ export async function handleEventSettlementBatch(events: Array<CosmosEvent>): Pr
   }
 
   if (modToAcctTransfers.length) {
-    await bulkInsertModToAcctTransfers(modToAcctTransfers);
+    const summarized = summarizeTransfers(modToAcctTransfers, new Map());
+    await Promise.all([
+      bulkInsertModToAcctTransfers(modToAcctTransfers),
+      bulkInsertSummarizedTransfers(summarized),
+    ]);
   }
 }


### PR DESCRIPTION
## Summary

- Add settlement aggregation fields to `EventClaimSettled` (settled/minted/overservicing/deflation amounts, mint ratio, supplier owner)
- Add optional fields to `EventApplicationOverserviced` (service, session end block height, spend limit exceeded)
- Extend `SettlementOpReason` enum with new relay burn-equals-mint and global mint TLM distribution reasons
- Fix burns/mints derivation for `reward_distribution_detailed` path by reading values directly from chain `op_reason` entries instead of broken math
- Handle `EventSettlementBatch` to save batched validator/delegator rewards as `ModToAcctTransfer` records
- Refactor `_handleEventClaimSettled` into smaller, focused functions

## Detail

**`schema.graphql`**:
- Add settlement aggregation fields to `EventClaimSettled`: `settledAmount`, `settledDenom`, `mintRatio`, `supplierOwner`, `mintedAmount`, `mintedDenom`, `overservicingLossAmount`, `overservicingLossDenom`, `deflationLossAmount`, `deflationLossDenom`
- Add optional fields to `EventApplicationOverserviced`: `service`, `sessionEndBlockHeight`, `spendLimitExceeded`
- Extend `SettlementOpReason` enum with relay burn-equals-mint and global mint TLM distribution reasons (DAO, source owner, application, validator, delegator, tokenomics mint)

**`proto/pocket/tokenomics/event.proto`**:
- Add proto definitions for new settlement aggregation event attributes
- Add `RewardDistributionDetail` message
- Add `EventSettlementBatch` message

**`src/mappings/pocket/relays.ts`**:
- Parse new event attributes: `reward_distribution_detailed`, `settled_upokt`, `minted_upokt`, `mint_ratio`, `supplier_owner_address`, `overservicing_loss_upokt`, `deflation_loss_upokt`, `num_estimated_relays`
- Refactor `_handleEventClaimSettled` into smaller functions:
  * `_resolveSettlementParts`
  * `_buildClaimSettledProps`
  * `_buildSettlementFromResult`
  * `_buildSettlementFromDetailedDistribution`
  * `_buildSettlementFromDistribution`
  * `_computeNumEstimatedRelays`
  * `_computeDeflationLoss`
  * `_computeOverservicingLoss`
- Build burns/mints from chain-provided values and `reward_distribution_detailed` `op_reason` entries instead of deriving them mathematically
- Add `handleEventSettlementBatch` to save batched validator/delegator rewards as `ModToAcctTransfer` records

**`src/mappings/handlers.ts`**:
- Wire `handleEventSettlementBatch` to `pocket.tokenomics.EventSettlementBatch`

**`src/mappings/indexer.manager.ts`**:
- Subscribe to `pocket.tokenomics.EventSettlementBatch` event type

**`project.ts`**:
- Register `EventSettlementBatch` event handler

## Issue

The previous implementation derived inflation and reimbursement mint amounts by computing `sum(reward_distribution) - (effectiveBurn × mintRatio)`. This broke at height 153753 (beta) because `reward_distribution_detailed` excludes proposer/validator rewards (they are batched separately via `EventSettlementBatch`), making the total less than `minted_upokt` and producing a negative value.

The fix:
- Extracts inflation and reimbursement directly from `reward_distribution_detailed` entries by `op_reason` (`TLM_GLOBAL_MINT_DAO_REWARD_DISTRIBUTION` and `TLM_GLOBAL_MINT_REIMBURSEMENT_REQUEST_ESCROW_DAO_TRANSFER`)
- Saves the batched validator/delegator rewards from `EventSettlementBatch` as `ModToAcctTransfer` records

## Type of change

Select one or more:

- [x] New feature, functionality or library
- [x] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## Sanity Checklist

- [x] I have tested my changes using the available tooling
- [x] I have commented my code
- [x] I have performed a self-review of my own code; both comments & source code
- [x] I create and reference any new tickets, if applicable
- [x] I have left TODOs throughout the codebase, if applicable