### PR TITLE
Add parallel mod_to_acct_transfers_summarized table

### DIFF
--- a/src/mappings/dbFunctions/index.ts
+++ b/src/mappings/dbFunctions/index.ts
@@ -11,7 +11,7 @@ import {
   getPerformanceIndexSqls,
   refreshDomainServiceDailyRewardsFn,
 } from "./domainRewards";
-import { createModToAcctTransfersTableFn } from "./modToAcctTransfers";
+import { createModToAcctTransfersTableFn, createModToAcctTransfersSummarizedTableFn } from "./modToAcctTransfers";
 import { getOverservicedsByDelegatorAddressesAndTimesFn } from "./overserviced";
 import { getComputeUnitsToTokensMultiplierEvolutionFn } from "./params";
 import { getRelaysByServicePerPointJsonFn } from "./relaysByServicePerPoint";
@@ -124,6 +124,7 @@ export async function createDbFunctions(): Promise<void> {
   await createFunctions(
     schema,
     createModToAcctTransfersTableFn,
+    createModToAcctTransfersSummarizedTableFn,
     createDomainServiceDailyRewardsTableFn,
     refreshDomainServiceDailyRewardsFn,
   )

--- a/src/mappings/dbFunctions/modToAcctTransfers.ts
+++ b/src/mappings/dbFunctions/modToAcctTransfers.ts
@@ -21,3 +21,26 @@ CREATE TABLE IF NOT EXISTS ${dbSchema}.mod_to_acct_transfers (
 );
 `;
 }
+
+export function createModToAcctTransfersSummarizedTableFn(dbSchema: string): string {
+  return `
+CREATE TABLE IF NOT EXISTS ${dbSchema}.mod_to_acct_transfers_summarized (
+  id              TEXT      NOT NULL,
+  block_id        NUMERIC   NOT NULL,
+  recipient_id    TEXT      NOT NULL,
+  op_reason       ${dbSchema}.c8206fb405 NOT NULL,
+  denom           TEXT      NOT NULL,
+  service_id      TEXT      NOT NULL DEFAULT '',
+  amount          BIGINT    NOT NULL,
+  transfer_count  BIGINT    NOT NULL DEFAULT 1,
+  _block_range    INT8RANGE NOT NULL,
+  PRIMARY KEY (id)
+);
+CREATE INDEX IF NOT EXISTS idx_mtat_summ_block_id
+  ON ${dbSchema}.mod_to_acct_transfers_summarized (block_id);
+CREATE INDEX IF NOT EXISTS idx_mtat_summ_recipient_block
+  ON ${dbSchema}.mod_to_acct_transfers_summarized (recipient_id, block_id);
+CREATE INDEX IF NOT EXISTS idx_mtat_summ_service_block
+  ON ${dbSchema}.mod_to_acct_transfers_summarized (service_id, block_id);
+`;
+}

--- a/src/mappings/pocket/relays.ts
+++ b/src/mappings/pocket/relays.ts
@@ -64,6 +64,17 @@ type ModToAcctTransferRecord = {
   denom: string;
 };
 
+type SummarizedTransferRecord = {
+  id: string;
+  blockId: bigint;
+  recipientId: string;
+  opReason: string;
+  denom: string;
+  serviceId: string;
+  amount: bigint;
+  transferCount: bigint;
+};
+
 // this can return undefined because older events do not have this attribute
 export function getClaimProofStatusFromSDK(item: typeof ClaimProofStatusSDKType | string | number): ClaimProofStatus | undefined {
   if (!item) return undefined;
@@ -1041,6 +1052,57 @@ async function bulkInsertModToAcctTransfers(records: ModToAcctTransferRecord[]):
   });
 }
 
+function summarizeTransfers(
+  records: ModToAcctTransferRecord[],
+  serviceIdByEventSettledId: Map<string, string>,
+): SummarizedTransferRecord[] {
+  if (records.length === 0) return [];
+
+  const grouped = new Map<string, SummarizedTransferRecord>();
+  const blockId = records[0].blockId;
+
+  for (const r of records) {
+    const serviceId = serviceIdByEventSettledId.get(r.eventClaimSettledId) || '';
+    const key = `${r.recipientId}|${r.opReason}|${r.denom}|${serviceId}`;
+
+    const existing = grouped.get(key);
+    if (existing) {
+      existing.amount += r.amount;
+      existing.transferCount += BigInt(1);
+    } else {
+      grouped.set(key, {
+        id: `${blockId}-${r.recipientId}-${r.opReason}-${r.denom}-${serviceId}`,
+        blockId,
+        recipientId: r.recipientId,
+        opReason: r.opReason,
+        denom: r.denom,
+        serviceId,
+        amount: r.amount,
+        transferCount: BigInt(1),
+      });
+    }
+  }
+
+  return Array.from(grouped.values());
+}
+
+async function bulkInsertSummarizedTransfers(records: SummarizedTransferRecord[]): Promise<void> {
+  if (records.length === 0) return;
+
+  const schema = getDbSchema();
+  const blockId = records[0].blockId;
+
+  await rawBulkInsert({
+    table: `${schema}.mod_to_acct_transfers_summarized`,
+    columns: ['id', 'block_id', 'recipient_id', 'op_reason', 'denom', 'service_id', 'amount', 'transfer_count', '_block_range'],
+    rows: records.map(r =>
+      `('${r.id}', ${r.blockId}, '${r.recipientId}', '${r.opReason}', '${r.denom}', '${r.serviceId}', ${r.amount}, ${r.transferCount}, int8range(${r.blockId}, null))`
+    ),
+    conflictCol: 'id',
+    blockId,
+  });
+}
+
 export async function handleMsgCreateClaim(messages: Array<CosmosMessage<MsgCreateClaim>>): Promise<void> {
   await optimizedBulkCreate("MsgCreateClaim", messages.map(_handleMsgCreateClaim), 'block_id');
 }
@@ -1063,6 +1125,7 @@ export async function handleEventClaimSettled(events: Array<CosmosEvent>, overse
 
   const eventsSettled = [];
   const modToAcctTransfersToSave = [];
+  const serviceIdByEventSettledId = new Map<string, string>();
 
   const effectiveBurnPerAppAndSupplier = overservices.reduce((acc, overservice) => {
     let effectiveBurn: CoinSDKType | undefined, application = '', supplier = '';
@@ -1095,15 +1158,19 @@ export async function handleEventClaimSettled(events: Array<CosmosEvent>, overse
   for (const event of events) {
     const [eventSettled, modToAcctTransfers] = _handleEventClaimSettled(event, mintRatio, getEffectiveBurn);
     eventsSettled.push(eventSettled);
+    serviceIdByEventSettledId.set(eventSettled.id as string, eventSettled.serviceId as string);
 
     if (modToAcctTransfers.length) {
       modToAcctTransfersToSave.push(...modToAcctTransfers);
     }
   }
 
+  const summarized = summarizeTransfers(modToAcctTransfersToSave, serviceIdByEventSettledId);
+
   await Promise.all([
     optimizedBulkCreate("EventClaimSettled", eventsSettled, 'block_id'),
     bulkInsertModToAcctTransfers(modToAcctTransfersToSave),
+    bulkInsertSummarizedTransfers(summarized),
   ]);
 }
 


### PR DESCRIPTION
## Summary
- Creates `mod_to_acct_transfers_summarized` table that groups by `(block_id, recipient_id, op_reason, denom, service_id)`, reducing row count ~45x on mainnet (1.6M → 36K per settlement block)
- Writes in parallel alongside the existing `mod_to_acct_transfers` table — no existing queries or functions are modified
- Adds `summarizeTransfers` pure function that aggregates `amount` (BigInt sum) and `transfer_count` per group key

## Files changed
- `src/mappings/dbFunctions/modToAcctTransfers.ts` — new table DDL with 3 indexes
- `src/mappings/dbFunctions/index.ts` — register table creation at startup
- `src/mappings/pocket/relays.ts` — summarization logic + parallel bulk insert

## Validated in production
- **Beta**: 5+ settlement blocks, all `sum(transfer_count)` match original row counts, all `sum(amount)` per recipient match
- **Mainnet**: 1 settlement block (680793), 1,656,445 original rows → 36,252 summarized rows (45.7x), perfect consistency

## What is NOT changed
- `mod_to_acct_transfers` table, functions, queries — all untouched
- `_handleEventClaimSettled` — untouched
- `bulkInsertModToAcctTransfers` — untouched

## Next steps (future PRs)
- Backfill historical data
- Validate completeness
- Switch functions to use summarized table
- Drop old table