### PR TITLE
fix: canonical validator ids and safe reconcile close-out

### DIFF
--- a/src/mappings/pocket/applications.ts
+++ b/src/mappings/pocket/applications.ts
@@ -1028,6 +1028,16 @@ export async function reconcileApplications(height: number): Promise<void> {
       continue;
     }
 
+    // An app cannot leave the chain store without unbonding first, and the
+    // unbonding-begin event already moved it to Unstaking when that block was
+    // processed. A Staked row missing from the chain is therefore an impossible
+    // state — a corrupt/partial chain read or an indexer bug — so close-out is
+    // restricted to Unstaking rows; anything else is reported, never wiped.
+    if (app.stakeStatus !== StakeStatus.Unstaking) {
+      logger.error(`[reconcileApplications] app ${app.id} is ${app.stakeStatus} in store but missing from chain at height ${height} — refusing close-out, investigate`);
+      continue;
+    }
+
     app.stakeStatus = StakeStatus.Unstaked;
     app.stakeAmount = BigInt(0);
     toUpsert.push(app);

--- a/src/mappings/pocket/validator.ts
+++ b/src/mappings/pocket/validator.ts
@@ -83,6 +83,22 @@ async function _handleValidatorMsgCreate(msg: CosmosMessage<MsgCreateValidator>)
     throw new Error("Pubkey is nil");
   }
 
+  // The staking module keys validators by operatorAddress, which is the
+  // canonical id every other consumer (reconcile, rewards/commission FKs)
+  // already assumes. Take it straight from the message instead of trusting the
+  // signer-pubkey derivation, and cross-check both: a mismatch means the
+  // derivation assumptions broke, and failing here is loud — unlike a silent
+  // row the reconciler would close out as Unstaked forever.
+  const operatorAddress = createValMsg.validatorAddress;
+
+  if (!operatorAddress) {
+    throw new Error(`[handleValidatorMsgCreate] (block ${msg.block.block.header.height}): hash=${msg.tx.hash} missing validatorAddress in MsgCreateValidator`);
+  }
+
+  if ((isMulti(signerInfo) || signerType === Secp256k1) && signerAddress !== operatorAddress) {
+    throw new Error(`[handleValidatorMsgCreate] (block ${msg.block.block.header.height}): hash=${msg.tx.hash} derived signer address ${signerAddress} != msg validatorAddress ${operatorAddress}`);
+  }
+
   const msgCreateValidator = MsgCreateValidatorEntity.create({
     id: msgId,
     pubkey: {
@@ -103,7 +119,7 @@ async function _handleValidatorMsgCreate(msg: CosmosMessage<MsgCreateValidator>)
   });
 
   const validator = Validator.create({
-    id: msgCreateValidator.signerId,
+    id: operatorAddress,
     ed25519_id: msgCreateValidator.address,
     signerId: msgCreateValidator.signerId,
     signerPoktPrefixId: poktSignerAddress,
@@ -229,6 +245,16 @@ export async function reconcileValidators(height: number): Promise<void> {
 
   for (const validator of tracked) {
     if (seen.has(validator.id)) {
+      continue;
+    }
+
+    // Same invariant as reconcileApplications: the staking module keeps a
+    // validator in its store (any bond status) until unbonding fully completes,
+    // and the unbonding trigger events already moved the row to Unstaking. A
+    // Staked row missing from the chain read is an impossible state — report it
+    // instead of wiping it.
+    if (validator.stakeStatus !== StakeStatus.Unstaking) {
+      logger.error(`[reconcileValidators] validator ${validator.id} is ${validator.stakeStatus} in store but missing from chain at height ${height} — refusing close-out, investigate`);
       continue;
     }
 

--- a/src/mappings/primitives/genesis.ts
+++ b/src/mappings/primitives/genesis.ts
@@ -863,7 +863,9 @@ async function _handleGenesisGenTxs(genesis: Genesis, block: CosmosBlock): Promi
         }
 
         validators.push({
-          id: validatorMsg.signerId,
+          // canonical staking id; the cross-check in _handleMsgCreateValidator
+          // guarantees it equals the derived signerId
+          id: (genTx.body.messages[0] as { validator_address: string }).validator_address,
           ed25519_id: validatorMsg.address,
           signerId: validatorMsg.signerId,
           signerPoktPrefixId: validatorMsg.signerPoktPrefixId,
@@ -931,6 +933,13 @@ function _handleMsgCreateValidator(genTx: GenesisTransaction, index: number, blo
   const signer = genTx.auth_info.signer_infos[0];
   const signerAddress = pubKeyToAddress(Secp256k1, fromBase64(signer.public_key.key), VALIDATOR_PREFIX);
   const poktSignerAddress = pubKeyToAddress(Secp256k1, fromBase64(signer.public_key.key), PREFIX);
+
+  // Same invariant as _handleValidatorMsgCreate: the gentx signer must be the
+  // staking operator, so the derived valoper address has to match the
+  // validator_address carried by the message itself.
+  if (signerAddress !== msg.validator_address) {
+    throw new Error(`[handleGenesisGenTxs] gen_tx ${index}: derived signer address ${signerAddress} != msg validator_address ${msg.validator_address}`);
+  }
 
   return {
     id: `genesis-gen-txs-${index}-0`,


### PR DESCRIPTION
Follow-up to #81, hardening two review findings with verified fixes.

## Validator id from `validatorAddress` (review point 3)

`Validator.id` now comes straight from `MsgCreateValidator.validatorAddress` — the canonical staking module key that `reconcileValidators` (keyed by `cv.operatorAddress`) and the reward/commission FKs already assume — instead of being re-derived from the tx signer pubkey. The derivation is kept as a cross-check that throws on mismatch, in both the tx handler and the genesis gentx path. Side effect: the `Unsupported Signer: ...` fallback can no longer leak into the entity id.

Verified on localnet with a clean reindex:
- genesis gentx validator: same id as before the change, cross-check silent
- live `MsgCreateValidator` tx: row created with `id == validator_address`, status correctly mirrors `BOND_STATUS_UNBONDED`
- 0 orphan `validator_rewards` FKs

## Close-out restricted to `Unstaking → Unstaked` (review point 2)

An entity cannot leave the chain store without unbonding first, and the unbonding-begin triggers already move rows to `Unstaking` when that block is processed. So the reconcile close-out now only transitions `Unstaking → Unstaked`; a `Staked` row missing from the chain read is an impossible state and gets logged as an error instead of being wiped. This bounds the blast radius of a hypothetical empty/partial chain read to rows already unbonding.

Note: the empty-read scenario itself cannot happen silently through this stack — cosmjs throws at every layer (HTTP ≥400, JSON-RPC error object, ABCI `code != 0`), so an empty list requires a genuinely successful response. This change is defense in depth plus indexer-bug detection.

Verified on localnet: live app unstake → `Unstaking` on the begin event → chain dropped the app at unbonding end → row transitioned to `Unstaked`/stake 0 within two blocks, zero false-positive error logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)