### PR TITLE
[Bug] Fix swapped nativeTransfers sender/recipient mapping (#84)

### DIFF
--- a/src/mappings/bank/transfer.ts
+++ b/src/mappings/bank/transfer.ts
@@ -27,8 +27,10 @@ function _handleNativeTransfer(msg: CosmosMessage<NativeTransferMsg>): NativeTra
   const denom = amounts[0].denom;
   return {
     id,
-    senderId: toAddress,
-    recipientId: fromAddress,
+    // fixes pocketdex#84: senderId/recipientId were swapped vs on-chain MsgSend.
+    // sender == MsgSend.fromAddress, recipient == MsgSend.toAddress.
+    senderId: fromAddress,
+    recipientId: toAddress,
     amounts,
     denom,
     status: getTxStatus(tx),


### PR DESCRIPTION
## Summary

The `MsgSend` handler built each `NativeTransfer` with the sender and recipient
inverted:

```ts
senderId: toAddress,      // was: the on-chain recipient
recipientId: fromAddress, // was: the on-chain sender
```

This commit swaps the assignment so `senderId == MsgSend.fromAddress` and
`recipientId == MsgSend.toAddress`, matching on-chain truth.

Verified against mainnet tx
`3A77623E8A921351395086000F11D2459E4496D8CF8F91149CCF5E0D4E7A7F93`: on-chain
`from_address` equals the DB `recipient_id` and `to_address` equals `sender_id`
— the exact inversion #84 reports, reproduced independently.

## Issue

Closes #84

- #84

## Historical data & cutover (no reindex)

Existing rows are uniformly swapped, the columns are `text` with no FK, and the
two GiST indexes are symmetric. So history is corrected **out-of-band via a
metadata-only column rename** (`sender_id` <-> `recipient_id`) — instant, zero
bloat, **no reindex/backfill**. The rename relabels all history; this code fix
governs all future rows. Both are required and do not cancel.

Downstream consumers that already compensate for the swap must drop their
workarounds **in lockstep** with the cutover, or they will invert again:

- poktscan-explorer: `TransferTable.tsx`, `app/api/export/queries.ts` (two query
  blocks). The export filter `(recipient_id OR sender_id)` is swap-invariant and
  stays as-is.
- Any external `data.pocket.network` GraphQL consumer — flagged for release notes.

## Type of change

- [x] Bug fix

## Testing

- [x] Confirmed swap empirically (mainnet tx vs on-chain MsgSend).

Testnet rehearsal (`explorer-testnet` / schema `beta`) before mainnet cutover:

1. Stop the indexer **and** the query component (no readers/writers on `native_transfers`).
2. Back up the testnet transfers table (`pg_dump` of `beta.native_transfers`).
3. Rename the columns (metadata-only swap, one transaction).
4. Deploy the indexer image built from this PR.
5. Verify: let the indexer process the next block(s) and/or submit fresh test sends;
   confirm new rows have `senderId == on-chain from_address` and
   `recipientId == on-chain to_address`, and that a previously-swapped historical
   row now reads correctly.
